### PR TITLE
Fix dispatch bugs and land agent output from VNM-45 runs

### DIFF
--- a/__tests__/integration/parallel-dispatch.test.ts
+++ b/__tests__/integration/parallel-dispatch.test.ts
@@ -45,6 +45,19 @@ vi.mock('../../src/modules/agents/worktree.js', () => ({
   findGitRoot: vi.fn(() => '/tmp/test-project'),
 }));
 
+vi.mock('../../src/modules/agents/wave-review.js', () => ({
+  reviewWave: vi.fn(() => ({
+    wave: 1,
+    taskCount: 0,
+    branches: [],
+    conflicts: [],
+    hasConflicts: false,
+    typecheckPassed: null,
+    lintPassed: null,
+    summary: 'Status: CLEAN',
+  })),
+}));
+
 import { monitorDelivery } from '../../src/modules/agents/delivery-monitor.js';
 
 const mockMonitorDelivery = monitorDelivery as ReturnType<typeof vi.fn>;
@@ -177,10 +190,10 @@ describe('parallel dispatch integration', () => {
     };
 
     const loop = new DispatchLoop(db, bp, spawnFn, '/tmp/test');
-    const results = await loop.executeWave({ wave: 1, taskIds });
+    const { settled } = await loop.executeWave({ wave: 1, taskIds });
 
-    expect(results).toHaveLength(3);
-    expect(results.every((r) => r.status === 'fulfilled')).toBe(true);
+    expect(settled).toHaveLength(3);
+    expect(settled.every((r) => r.status === 'fulfilled')).toBe(true);
 
     // All 3 agents created
     const agents = db.prepare('SELECT * FROM agents').all() as Record<string, unknown>[];
@@ -215,13 +228,13 @@ describe('parallel dispatch integration', () => {
     // Dispatch 4 tasks — should be gated by WIP=2
     // Note: with mocked sleep, WIP polling resolves immediately,
     // so this tests the logic path rather than actual concurrency timing
-    const results = await loop.executeWave({
+    const { settled } = await loop.executeWave({
       wave: 1,
       taskIds: ['t1', 't2', 't3', 't4'],
     });
 
-    expect(results).toHaveLength(4);
-    expect(results.every((r) => r.status === 'fulfilled')).toBe(true);
+    expect(settled).toHaveLength(4);
+    expect(settled.every((r) => r.status === 'fulfilled')).toBe(true);
   });
 
   it('handles mixed success and failure in a wave', async () => {
@@ -238,14 +251,14 @@ describe('parallel dispatch integration', () => {
     };
 
     const loop = new DispatchLoop(db, bp, spawnFn, '/tmp/test');
-    const results = await loop.executeWave({
+    const { settled } = await loop.executeWave({
       wave: 1,
       taskIds: ['t1', 't2', 't3'],
     });
 
     // All should settle (Promise.allSettled), none should be rejected
-    expect(results).toHaveLength(3);
-    expect(results.every((r) => r.status === 'fulfilled')).toBe(true);
+    expect(settled).toHaveLength(3);
+    expect(settled.every((r) => r.status === 'fulfilled')).toBe(true);
 
     // t1 and t3 should have agents, t2 should not (spawn failed)
     const agents = db.prepare('SELECT * FROM agents').all() as Record<string, unknown>[];

--- a/__tests__/modules/agents/cost-aggregation.test.ts
+++ b/__tests__/modules/agents/cost-aggregation.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import {
+  summarizeCosts,
+  aggregateByPeriod,
+  aggregateByWorkstream,
+  checkBudgetAlerts,
+  type AgentCostEntry,
+  type BudgetThresholds,
+} from '../../../src/modules/agents/cost-aggregation.js';
+
+function entry(overrides: Partial<AgentCostEntry> = {}): AgentCostEntry {
+  return {
+    agentId: 'a1',
+    name: 'worker-1',
+    task: 'VNM-45.01',
+    status: 'completed',
+    costUsd: 0.5,
+    durationMs: 60_000,
+    tokensInput: 10_000,
+    tokensOutput: 5_000,
+    createdAt: '2026-04-09T10:00:00Z',
+    completedAt: '2026-04-09T10:01:00Z',
+    ...overrides,
+  };
+}
+
+describe('summarizeCosts', () => {
+  it('returns zeros for empty entries', () => {
+    const result = summarizeCosts([]);
+    expect(result.totalCostUsd).toBe(0);
+    expect(result.agentCount).toBe(0);
+  });
+
+  it('aggregates costs across entries', () => {
+    const entries = [
+      entry({ costUsd: 1.5, tokensInput: 100, tokensOutput: 50 }),
+      entry({ agentId: 'a2', costUsd: 2.0, tokensInput: 200, tokensOutput: 100 }),
+    ];
+    const result = summarizeCosts(entries);
+    expect(result.totalCostUsd).toBe(3.5);
+    expect(result.agentCount).toBe(2);
+    expect(result.totalTokensInput).toBe(300);
+    expect(result.totalTokensOutput).toBe(150);
+  });
+});
+
+describe('aggregateByPeriod', () => {
+  it('groups by day', () => {
+    const entries = [
+      entry({ createdAt: '2026-04-08T10:00:00Z', costUsd: 1.0 }),
+      entry({ createdAt: '2026-04-08T14:00:00Z', costUsd: 0.5 }),
+      entry({ createdAt: '2026-04-09T10:00:00Z', costUsd: 2.0 }),
+    ];
+    const result = aggregateByPeriod(entries, 'day');
+    expect(result).toHaveLength(2);
+    expect(result[0].period).toBe('2026-04-08');
+    expect(result[0].costUsd).toBe(1.5);
+    expect(result[0].agentCount).toBe(2);
+    expect(result[1].period).toBe('2026-04-09');
+    expect(result[1].costUsd).toBe(2.0);
+  });
+
+  it('groups by week', () => {
+    const entries = [
+      entry({ createdAt: '2026-03-30T10:00:00Z', costUsd: 1.0 }),
+      entry({ createdAt: '2026-04-08T10:00:00Z', costUsd: 2.0 }),
+    ];
+    const result = aggregateByPeriod(entries, 'week');
+    expect(result.length).toBeGreaterThanOrEqual(2);
+    expect(result.every((r) => r.period.startsWith('W'))).toBe(true);
+  });
+
+  it('returns empty for no entries', () => {
+    expect(aggregateByPeriod([], 'day')).toEqual([]);
+  });
+});
+
+describe('aggregateByWorkstream', () => {
+  it('extracts workstream from task ID', () => {
+    const entries = [
+      entry({ task: 'VNM-45.01', costUsd: 1.0 }),
+      entry({ task: 'VNM-45.02', costUsd: 2.0 }),
+      entry({ task: 'VNM-12.03', costUsd: 0.5 }),
+    ];
+    const result = aggregateByWorkstream(entries);
+    expect(result).toHaveLength(2);
+
+    const vnm45 = result.find((r) => r.workstream === 'VNM-45');
+    expect(vnm45?.costUsd).toBe(3.0);
+    expect(vnm45?.agentCount).toBe(2);
+
+    const vnm12 = result.find((r) => r.workstream === 'VNM-12');
+    expect(vnm12?.costUsd).toBe(0.5);
+  });
+
+  it('labels unassigned agents', () => {
+    const entries = [entry({ task: null, costUsd: 1.0 })];
+    const result = aggregateByWorkstream(entries);
+    expect(result[0].workstream).toBe('(unassigned)');
+  });
+});
+
+describe('checkBudgetAlerts', () => {
+  const today = new Date();
+  const todayIso = today.toISOString();
+
+  it('returns empty when no thresholds configured', () => {
+    const entries = [entry({ createdAt: todayIso, costUsd: 100 })];
+    expect(checkBudgetAlerts(entries, {})).toEqual([]);
+  });
+
+  it('returns warning when daily spend exceeds warn threshold', () => {
+    const entries = [entry({ createdAt: todayIso, costUsd: 5.0 })];
+    const thresholds: BudgetThresholds = { dailyWarnUsd: 3.0 };
+    const alerts = checkBudgetAlerts(entries, thresholds);
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].level).toBe('warning');
+    expect(alerts[0].period).toBe('daily');
+  });
+
+  it('returns critical when daily spend exceeds critical threshold', () => {
+    const entries = [entry({ createdAt: todayIso, costUsd: 10.0 })];
+    const thresholds: BudgetThresholds = {
+      dailyWarnUsd: 3.0,
+      dailyCriticalUsd: 8.0,
+    };
+    const alerts = checkBudgetAlerts(entries, thresholds);
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].level).toBe('critical');
+  });
+
+  it('returns weekly warning', () => {
+    const entries = [entry({ createdAt: todayIso, costUsd: 20.0 })];
+    const thresholds: BudgetThresholds = { weeklyWarnUsd: 15.0 };
+    const alerts = checkBudgetAlerts(entries, thresholds);
+    expect(alerts.some((a) => a.period === 'weekly' && a.level === 'warning')).toBe(true);
+  });
+
+  it('ignores old entries for daily threshold', () => {
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+    const entries = [entry({ createdAt: yesterday.toISOString(), costUsd: 100 })];
+    const thresholds: BudgetThresholds = { dailyWarnUsd: 1.0 };
+    const alerts = checkBudgetAlerts(entries, thresholds);
+    const dailyAlerts = alerts.filter((a) => a.period === 'daily');
+    expect(dailyAlerts).toHaveLength(0);
+  });
+});

--- a/__tests__/modules/agents/cost-aggregation.test.ts
+++ b/__tests__/modules/agents/cost-aggregation.test.ts
@@ -145,4 +145,37 @@ describe('checkBudgetAlerts', () => {
     const dailyAlerts = alerts.filter((a) => a.period === 'daily');
     expect(dailyAlerts).toHaveLength(0);
   });
+
+  it('includes current-week entries on Sunday', () => {
+    // Find next Sunday from today
+    const sunday = new Date(today);
+    sunday.setDate(sunday.getDate() + ((7 - sunday.getDay()) % 7) || 7);
+    sunday.setHours(12, 0, 0, 0);
+    // Monday of that week
+    const monday = new Date(sunday);
+    monday.setDate(monday.getDate() - 6);
+    monday.setHours(10, 0, 0, 0);
+
+    const entries = [entry({ createdAt: monday.toISOString(), costUsd: 20.0 })];
+    const thresholds: BudgetThresholds = { weeklyWarnUsd: 15.0 };
+    // Mock Date.now to return Sunday
+    const origNow = Date.now;
+    Date.now = () => sunday.getTime();
+    const OrigDate = globalThis.Date;
+    const MockDate = class extends OrigDate {
+      constructor(...args: unknown[]) {
+        if (args.length === 0) super(sunday.getTime());
+        else super(...(args as [number]));
+      }
+    } as DateConstructor;
+    globalThis.Date = MockDate;
+
+    try {
+      const alerts = checkBudgetAlerts(entries, thresholds);
+      expect(alerts.some((a) => a.period === 'weekly')).toBe(true);
+    } finally {
+      globalThis.Date = OrigDate;
+      Date.now = origNow;
+    }
+  });
 });

--- a/__tests__/modules/agents/dispatch-loop.test.ts
+++ b/__tests__/modules/agents/dispatch-loop.test.ts
@@ -26,6 +26,10 @@ vi.mock('../../../src/modules/agents/delivery-monitor.js', () => ({
   monitorDelivery: vi.fn(),
 }));
 
+vi.mock('../../../src/modules/agents/wave-review.js', () => ({
+  reviewWave: vi.fn(),
+}));
+
 import {
   checkDispatchConcurrency,
   DispatchLoop,
@@ -35,6 +39,7 @@ import { countActiveAgents, getAgent } from '../../../src/modules/agents/data.js
 import { getDeliveryForTask, initiateDelivery } from '../../../src/modules/agents/delivery.js';
 import { releaseWorktree } from '../../../src/modules/agents/worktree.js';
 import { monitorDelivery } from '../../../src/modules/agents/delivery-monitor.js';
+import { reviewWave } from '../../../src/modules/agents/wave-review.js';
 
 const mockCountActive = countActiveAgents as ReturnType<typeof vi.fn>;
 const mockGetAgent = getAgent as ReturnType<typeof vi.fn>;
@@ -42,6 +47,7 @@ const mockGetDelivery = getDeliveryForTask as ReturnType<typeof vi.fn>;
 const mockInitiateDelivery = initiateDelivery as ReturnType<typeof vi.fn>;
 const mockReleaseWorktree = releaseWorktree as ReturnType<typeof vi.fn>;
 const mockMonitorDelivery = monitorDelivery as ReturnType<typeof vi.fn>;
+const mockReviewWave = reviewWave as ReturnType<typeof vi.fn>;
 
 const fakeDb = {} as unknown;
 const projectDir = '/tmp/test-project';
@@ -84,6 +90,17 @@ describe('DispatchLoop', () => {
     spawnFn = vi.fn();
     // Default: WIP slot available
     mockCountActive.mockReturnValue(0);
+    // Default: clean wave review
+    mockReviewWave.mockReturnValue({
+      wave: 1,
+      taskCount: 0,
+      branches: [],
+      conflicts: [],
+      hasConflicts: false,
+      typecheckPassed: null,
+      lintPassed: null,
+      summary: 'Status: CLEAN',
+    });
   });
 
   afterEach(() => vi.restoreAllMocks());
@@ -193,26 +210,26 @@ describe('DispatchLoop', () => {
   });
 
   describe('executeWave', () => {
-    it('dispatches all tasks in wave concurrently', async () => {
-      // Both tasks succeed immediately
+    it('dispatches all tasks in wave and returns review', async () => {
       spawnFn.mockResolvedValue({ agentId: 'a1', taskId: 't1', branch: 'b1' });
       mockGetAgent.mockReturnValue({ status: 'completed' });
       mockGetDelivery.mockReturnValue(null);
       mockInitiateDelivery.mockReturnValue({ agent_id: 'a1', task_id: 't1' });
       mockMonitorDelivery.mockResolvedValue('merged');
 
-      const results = await makeLoop().executeWave({
+      const { settled, review } = await makeLoop().executeWave({
         wave: 1,
         taskIds: ['t1', 't2'],
       });
 
-      expect(results).toHaveLength(2);
-      expect(results.every((r) => r.status === 'fulfilled')).toBe(true);
+      expect(settled).toHaveLength(2);
+      expect(settled.every((r) => r.status === 'fulfilled')).toBe(true);
       expect(spawnFn).toHaveBeenCalledTimes(2);
+      expect(mockReviewWave).toHaveBeenCalledWith(fakeDb, 1, ['t1', 't2'], projectDir);
+      expect(review.hasConflicts).toBe(false);
     });
 
     it('settles all tasks even when some fail', async () => {
-      // First task spawns fine, second fails
       spawnFn
         .mockResolvedValueOnce({ agentId: 'a1', taskId: 't1', branch: 'b1' })
         .mockRejectedValueOnce(new Error('spawn fail'));
@@ -221,14 +238,40 @@ describe('DispatchLoop', () => {
       mockInitiateDelivery.mockReturnValue({ agent_id: 'a1', task_id: 't1' });
       mockMonitorDelivery.mockResolvedValue('merged');
 
-      const results = await makeLoop().executeWave({
+      const { settled } = await makeLoop().executeWave({
         wave: 1,
         taskIds: ['t1', 't2'],
       });
 
-      expect(results).toHaveLength(2);
-      // Both should settle (allSettled), not reject
-      expect(results.every((r) => r.status === 'fulfilled')).toBe(true);
+      expect(settled).toHaveLength(2);
+      expect(settled.every((r) => r.status === 'fulfilled')).toBe(true);
+    });
+
+    it('reports conflicts from wave review', async () => {
+      spawnFn.mockResolvedValue({ agentId: 'a1', taskId: 't1', branch: 'b1' });
+      mockGetAgent.mockReturnValue({ status: 'completed' });
+      mockGetDelivery.mockReturnValue(null);
+      mockInitiateDelivery.mockReturnValue({ agent_id: 'a1', task_id: 't1' });
+      mockMonitorDelivery.mockResolvedValue('merged');
+      mockReviewWave.mockReturnValue({
+        wave: 1,
+        taskCount: 2,
+        branches: [],
+        conflicts: [{ file: 'src/shared.ts', branches: ['b1', 'b2'], taskIds: ['t1', 't2'] }],
+        hasConflicts: true,
+        typecheckPassed: null,
+        lintPassed: null,
+        summary: 'CONFLICTS\nStatus: BLOCKED',
+      });
+
+      const { review } = await makeLoop().executeWave({
+        wave: 1,
+        taskIds: ['t1', 't2'],
+      });
+
+      expect(review.hasConflicts).toBe(true);
+      expect(review.conflicts).toHaveLength(1);
+      expect(review.summary).toContain('BLOCKED');
     });
   });
 });

--- a/__tests__/modules/agents/worktree.test.ts
+++ b/__tests__/modules/agents/worktree.test.ts
@@ -26,14 +26,15 @@ vi.mock('node:child_process', () => ({
 
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
-  return { ...actual, existsSync: vi.fn() };
+  return { ...actual, existsSync: vi.fn(), cpSync: vi.fn() };
 });
 
 import { execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, cpSync } from 'node:fs';
 
 const mockExecFileSync = execFileSync as ReturnType<typeof vi.fn>;
 const mockExistsSync = existsSync as ReturnType<typeof vi.fn>;
+const mockCpSync = cpSync as ReturnType<typeof vi.fn>;
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
@@ -187,6 +188,44 @@ describe('worktree lifecycle', () => {
           claimToken: 'tok-1',
         })
       ).toThrow('workstream is empty');
+    });
+
+    it('copies .claude directory into worktree for hook discovery', () => {
+      // .claude exists in project root, does not exist in worktree yet
+      mockExistsSync.mockImplementation((p: unknown) => {
+        const path = p as string;
+        if (path === '/repo/.claude') return true;
+        if (path.endsWith('.claude')) return false;
+        return true;
+      });
+
+      allocateWorktree(db, '/repo', {
+        taskId: 'VNM-09.05',
+        workstream: 'vnm-09',
+        claimToken: 'tok-5',
+        budget: 3,
+      });
+
+      expect(mockCpSync).toHaveBeenCalledWith('/repo/.claude', expect.stringContaining('.claude'), {
+        recursive: true,
+      });
+    });
+
+    it('skips .claude copy when source does not exist', () => {
+      mockExistsSync.mockImplementation((p: unknown) => {
+        const path = p as string;
+        if (path.endsWith('.claude')) return false;
+        return true;
+      });
+
+      allocateWorktree(db, '/repo', {
+        taskId: 'VNM-09.06',
+        workstream: 'vnm-09',
+        claimToken: 'tok-6',
+        budget: 3,
+      });
+
+      expect(mockCpSync).not.toHaveBeenCalled();
     });
 
     it('uses default basePath and budget when not supplied', () => {

--- a/__tests__/modules/autoloop/enrichment-writer.test.ts
+++ b/__tests__/modules/autoloop/enrichment-writer.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+  };
+});
+
+vi.mock('node:crypto', () => ({
+  createHash: () => ({ update: () => ({ digest: () => 'fakehash' }) }),
+}));
+
+vi.mock('../../../src/modules/pm/data/queries.js', () => ({
+  getPmNotes: vi.fn(),
+}));
+
+vi.mock('../../../src/services/indexing.js', () => ({
+  indexSingleFile: vi.fn(),
+}));
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { getPmNotes } from '../../../src/modules/pm/data/queries.js';
+import { indexSingleFile } from '../../../src/services/indexing.js';
+import { writeEnrichmentToTask } from '../../../src/modules/autoloop/engine/enrichment-writer.js';
+import type { EnrichmentSuggestion } from '../../../src/modules/autoloop/engine/task-enricher.js';
+
+const mockExistsSync = existsSync as ReturnType<typeof vi.fn>;
+const mockReadFileSync = readFileSync as ReturnType<typeof vi.fn>;
+const mockWriteFileSync = writeFileSync as ReturnType<typeof vi.fn>;
+const mockGetPmNotes = getPmNotes as ReturnType<typeof vi.fn>;
+const mockIndexSingleFile = indexSingleFile as ReturnType<typeof vi.fn>;
+
+function makeSuggestion(overrides: Partial<EnrichmentSuggestion> = {}): EnrichmentSuggestion {
+  return {
+    taskId: 'VNM-45.01',
+    suggestedAdditions: [],
+    relatedResearch: [],
+    relatedMemories: [],
+    ...overrides,
+  };
+}
+
+describe('writeEnrichmentToTask', () => {
+  const fakeDb = {} as never;
+  const fakeEmbedder = {} as never;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('---\ntitle: Task\n---\n\nSome content');
+    mockGetPmNotes.mockReturnValue([{ filePath: '/notes/task.md' }]);
+    mockIndexSingleFile.mockResolvedValue(undefined);
+  });
+
+  it('skips when no matching note found', async () => {
+    mockGetPmNotes.mockReturnValue([]);
+    await writeEnrichmentToTask(fakeDb, fakeEmbedder, makeSuggestion());
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+
+  it('skips when note file does not exist on disk', async () => {
+    mockExistsSync.mockReturnValue(false);
+    await writeEnrichmentToTask(fakeDb, fakeEmbedder, makeSuggestion());
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+
+  it('skips when already enriched', async () => {
+    mockReadFileSync.mockReturnValue(
+      '---\ntitle: Task\n---\n\n## Enrichment Context\n\nAlready here'
+    );
+    await writeEnrichmentToTask(
+      fakeDb,
+      fakeEmbedder,
+      makeSuggestion({
+        relatedResearch: [{ title: 'Test', relevance: 0.9, excerpt: 'excerpt' }],
+      })
+    );
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+
+  it('skips when suggestion has no research or memories', async () => {
+    await writeEnrichmentToTask(fakeDb, fakeEmbedder, makeSuggestion());
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+
+  it('appends research section and re-indexes', async () => {
+    const suggestion = makeSuggestion({
+      relatedResearch: [{ title: 'Paper A', relevance: 0.85, excerpt: 'Key finding' }],
+    });
+    await writeEnrichmentToTask(fakeDb, fakeEmbedder, suggestion);
+
+    expect(mockWriteFileSync).toHaveBeenCalledOnce();
+    const written = mockWriteFileSync.mock.calls[0][1] as string;
+    expect(written).toContain('## Enrichment Context');
+    expect(written).toContain('### Related Research');
+    expect(written).toContain('Paper A');
+    expect(written).toContain('Key finding');
+
+    expect(mockIndexSingleFile).toHaveBeenCalledOnce();
+  });
+
+  it('appends memories section', async () => {
+    const suggestion = makeSuggestion({
+      relatedMemories: ['User prefers TDD', 'Project uses Vitest'],
+    });
+    await writeEnrichmentToTask(fakeDb, fakeEmbedder, suggestion);
+
+    const written = mockWriteFileSync.mock.calls[0][1] as string;
+    expect(written).toContain('### Related Memories');
+    expect(written).toContain('User prefers TDD');
+    expect(written).toContain('Project uses Vitest');
+  });
+
+  it('truncates long excerpts to 200 chars', async () => {
+    const longExcerpt = 'x'.repeat(300);
+    const suggestion = makeSuggestion({
+      relatedResearch: [{ title: 'Long', relevance: 0.9, excerpt: longExcerpt }],
+    });
+    await writeEnrichmentToTask(fakeDb, fakeEmbedder, suggestion);
+
+    const written = mockWriteFileSync.mock.calls[0][1] as string;
+    const excerptLine = written.split('\n').find((l: string) => l.includes('> '));
+    expect(excerptLine!.length).toBeLessThan(250);
+  });
+});

--- a/__tests__/server/orchestration.test.ts
+++ b/__tests__/server/orchestration.test.ts
@@ -25,7 +25,21 @@ vi.mock('../../src/modules/pm/data/task-ops.js', () => ({
 vi.mock('../../src/modules/agents/dispatch-loop.js', () => {
   return {
     DispatchLoop: vi.fn().mockImplementation(() => ({
-      executeWave: vi.fn(() => Promise.resolve([])),
+      executeWave: vi.fn(() =>
+        Promise.resolve({
+          settled: [],
+          review: {
+            wave: 1,
+            taskCount: 0,
+            branches: [],
+            conflicts: [],
+            hasConflicts: false,
+            typecheckPassed: null,
+            lintPassed: null,
+            summary: 'CLEAN',
+          },
+        })
+      ),
     })),
   };
 });
@@ -227,7 +241,17 @@ describe('OrchestrationService', () => {
         { wave: 2, taskIds: ['VNM-48.103'] },
       ]);
 
-      const executeWaveFn = vi.fn(() => Promise.resolve([]));
+      const cleanReview = {
+        wave: 1,
+        taskCount: 0,
+        branches: [],
+        conflicts: [],
+        hasConflicts: false,
+        typecheckPassed: null,
+        lintPassed: null,
+        summary: 'CLEAN',
+      };
+      const executeWaveFn = vi.fn(() => Promise.resolve({ settled: [], review: cleanReview }));
       (DispatchLoop as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
         executeWave: executeWaveFn,
       }));
@@ -250,7 +274,17 @@ describe('OrchestrationService', () => {
         { wave: 1, taskIds: ['VNM-48.101', 'VNM-47.001'] }, // VNM-47.001 is another workstream
       ]);
 
-      const executeWaveFn = vi.fn(() => Promise.resolve([]));
+      const cleanReview = {
+        wave: 1,
+        taskCount: 0,
+        branches: [],
+        conflicts: [],
+        hasConflicts: false,
+        typecheckPassed: null,
+        lintPassed: null,
+        summary: 'CLEAN',
+      };
+      const executeWaveFn = vi.fn(() => Promise.resolve({ settled: [], review: cleanReview }));
       (DispatchLoop as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
         executeWave: executeWaveFn,
       }));

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -3,6 +3,14 @@ import type { BrainDB } from '../services/brain-db.js';
 import type { BrainConfig } from '../types.js';
 import { listAgents, getAgentContext } from '../modules/agents/data.js';
 import { getPmNotes as _getPmNotes } from '../modules/pm/data/queries.js';
+import {
+  getAgentCostEntries,
+  summarizeCosts,
+  aggregateByPeriod,
+  aggregateByWorkstream,
+  checkBudgetAlerts,
+  loadBudgetThresholds,
+} from '../modules/agents/cost-aggregation.js';
 
 export interface AuditNotes {
   total: number;
@@ -198,6 +206,8 @@ export interface DashboardAgent {
   toolCalls: number;
   errors: number;
   toolDomains: string[];
+  costUsd: number;
+  durationMs: number;
 }
 
 export interface SessionTimelineEvent {
@@ -232,12 +242,21 @@ export interface DashboardStageTransition {
   timestamp: string;
 }
 
+export interface DashboardCostSummaryLocal {
+  totalCostUsd: number;
+  totalAgents: number;
+  byPeriod: Array<{ period: string; costUsd: number; agentCount: number }>;
+  byWorkstream: Array<{ workstream: string; costUsd: number; agentCount: number }>;
+  alerts: Array<{ level: string; message: string; period: string }>;
+}
+
 export interface DashboardData {
   tasks: DashboardTask[];
   agents: DashboardAgent[];
   sessions: DashboardSession[];
   stageHistory: DashboardStageTransition[];
   workstreams: Record<string, { name: string; project: string }>;
+  costs?: DashboardCostSummaryLocal;
 }
 
 function readNoteBody(filePath: string): string | undefined {
@@ -347,6 +366,9 @@ function collectDashboardAgents(db: BrainDB): DashboardAgent[] {
       const toolCalls = (getAgentContext(rawDb, a.id, 'total_tool_calls') as number) ?? 0;
       const errors = (getAgentContext(rawDb, a.id, 'total_errors') as number) ?? 0;
       const toolDomains = (getAgentContext(rawDb, a.id, 'tool_domains') as string[]) ?? [];
+      const claudeResult = getAgentContext(rawDb, a.id, 'claude_result') as
+        | { total_cost_usd?: number; duration_ms?: number }
+        | undefined;
 
       return {
         id: a.id,
@@ -359,6 +381,8 @@ function collectDashboardAgents(db: BrainDB): DashboardAgent[] {
         toolCalls,
         errors,
         toolDomains,
+        costUsd: claudeResult?.total_cost_usd ?? 0,
+        durationMs: claudeResult?.duration_ms ?? 0,
       };
     });
   } catch {
@@ -461,6 +485,36 @@ function collectStageHistory(db: BrainDB): DashboardStageTransition[] {
   return transitions.sort((a, b) => b.timestamp.localeCompare(a.timestamp)).slice(0, 200);
 }
 
+function collectCostSummary(db: BrainDB): DashboardCostSummaryLocal {
+  try {
+    const rawDb = (db as unknown as { db: unknown }).db;
+    const entries = getAgentCostEntries(rawDb);
+    const summary = summarizeCosts(entries);
+    const thresholds = loadBudgetThresholds();
+    const alerts = checkBudgetAlerts(entries, thresholds);
+
+    return {
+      totalCostUsd: summary.totalCostUsd,
+      totalAgents: summary.agentCount,
+      byPeriod: aggregateByPeriod(entries, 'day'),
+      byWorkstream: aggregateByWorkstream(entries),
+      alerts: alerts.map((a) => ({
+        level: a.level,
+        message: a.message,
+        period: a.period,
+      })),
+    };
+  } catch {
+    return {
+      totalCostUsd: 0,
+      totalAgents: 0,
+      byPeriod: [],
+      byWorkstream: [],
+      alerts: [],
+    };
+  }
+}
+
 export function collectDashboardData(db: BrainDB, config?: BrainConfig): DashboardData {
   const notesDir = config?.notesDir ?? '';
   const { tasks, workstreams } = collectDashboardTasks(db);
@@ -470,6 +524,7 @@ export function collectDashboardData(db: BrainDB, config?: BrainConfig): Dashboa
     sessions: collectDashboardSessions(db, notesDir),
     stageHistory: collectStageHistory(db),
     workstreams,
+    costs: collectCostSummary(db),
   };
 }
 

--- a/src/dashboard/types.ts
+++ b/src/dashboard/types.ts
@@ -89,6 +89,16 @@ export interface DashboardAgent {
   toolCalls: number;
   errors: number;
   toolDomains: string[];
+  costUsd: number;
+  durationMs: number;
+}
+
+export interface DashboardCostSummary {
+  totalCostUsd: number;
+  totalAgents: number;
+  byPeriod: Array<{ period: string; costUsd: number; agentCount: number }>;
+  byWorkstream: Array<{ workstream: string; costUsd: number; agentCount: number }>;
+  alerts: Array<{ level: string; message: string; period: string }>;
 }
 
 export interface SessionTimelineEvent {
@@ -129,6 +139,7 @@ export interface DashboardData {
   sessions: DashboardSession[];
   stageHistory: DashboardStageTransition[];
   workstreams: Record<string, { name: string; project: string }>;
+  costs?: DashboardCostSummary;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/dashboard/views/AgentsView.tsx
+++ b/src/dashboard/views/AgentsView.tsx
@@ -8,6 +8,7 @@ import { fmtK } from '../utils/formatting.js';
 import { AgentCard } from '../components/AgentCard.js';
 import { Avatar } from '../components/shared/Avatar.js';
 import { statusColor } from '../utils/semantic-colors.js';
+import { CostsView } from './CostsView.js';
 
 interface AgentsViewProps {
   dashboard: DashboardData | null;
@@ -176,7 +177,7 @@ function TopoNode({ agent, role, index: _index, isDimmed }: TopoNodeProps) {
 // ---------------------------------------------------------------------------
 // Toggle bar + main view
 // ---------------------------------------------------------------------------
-type ViewMode = 'status' | 'topology';
+type ViewMode = 'status' | 'topology' | 'costs';
 
 export function AgentsView({ dashboard, initialAgent }: AgentsViewProps) {
   const [mode, setMode] = useState<ViewMode>('status');
@@ -210,6 +211,14 @@ export function AgentsView({ dashboard, initialAgent }: AgentsViewProps) {
               Topology
             </Text>
           </Pressable>
+          <Pressable
+            style={[s.toggleBtn, mode === 'costs' && s.toggleBtnActive]}
+            onPress={() => setMode('costs')}
+          >
+            <Text style={[s.toggleBtnText, mode === 'costs' && s.toggleBtnTextActive]}>
+              Costs
+            </Text>
+          </Pressable>
         </View>
 
         <Pressable
@@ -226,10 +235,15 @@ export function AgentsView({ dashboard, initialAgent }: AgentsViewProps) {
         <Text style={s.hiddenHint}>{historicalCount} historical agent{historicalCount !== 1 ? 's' : ''} hidden</Text>
       )}
 
-      {mode === 'status'
-        ? <StatusCardsView agents={visibleAgents} highlightedAgent={highlightedAgent} dimHistorical={showHistorical} />
-        : <TopologyView agents={visibleAgents} dimHistorical={showHistorical} />
-      }
+      {mode === 'status' && (
+        <StatusCardsView agents={visibleAgents} highlightedAgent={highlightedAgent} dimHistorical={showHistorical} />
+      )}
+      {mode === 'topology' && (
+        <TopologyView agents={visibleAgents} dimHistorical={showHistorical} />
+      )}
+      {mode === 'costs' && (
+        <CostsView dashboard={dashboard} />
+      )}
     </View>
   );
 }

--- a/src/dashboard/views/CostsView.tsx
+++ b/src/dashboard/views/CostsView.tsx
@@ -1,0 +1,322 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import type { DashboardData } from '../types.js';
+import { C } from '../components/shared/colors.js';
+import { type as T } from '../tokens.js';
+
+interface CostsViewProps {
+  dashboard: DashboardData | null;
+}
+
+function fmtUsd(n: number): string {
+  return `$${n.toFixed(2)}`;
+}
+
+function AlertBanner({ alerts }: { alerts: Array<{ level: string; message: string }> }) {
+  if (alerts.length === 0) return null;
+
+  return (
+    <View style={s.alertContainer}>
+      {alerts.map((alert, i) => (
+        <View
+          key={i}
+          style={[
+            s.alertRow,
+            alert.level === 'critical' ? s.alertCritical : s.alertWarning,
+          ]}
+        >
+          <Text style={s.alertIcon}>{alert.level === 'critical' ? '!!' : '!'}</Text>
+          <Text style={s.alertText}>{alert.message}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function SummaryCards({ totalCost, totalAgents }: { totalCost: number; totalAgents: number }) {
+  const avgCost = totalAgents > 0 ? totalCost / totalAgents : 0;
+
+  const stats: [string, string, string][] = [
+    ['Total Spend', fmtUsd(totalCost), C.textPrimary],
+    ['Agents', String(totalAgents), C.info],
+    ['Avg / Agent', fmtUsd(avgCost), C.textSecondary],
+  ];
+
+  return (
+    <View style={s.statsBar}>
+      {stats.map(([label, value, color]) => (
+        <View key={label} style={s.statCard}>
+          <Text style={s.statLabel}>{label}</Text>
+          <Text style={[s.statValue, { color }]}>{value}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function CostTable({
+  title,
+  headers,
+  rows,
+}: {
+  title: string;
+  headers: string[];
+  rows: Array<[string, string, string]>;
+}) {
+  if (rows.length === 0) {
+    return (
+      <View style={s.tableContainer}>
+        <Text style={s.tableTitle}>{title}</Text>
+        <Text style={s.emptyText}>No cost data available.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={s.tableContainer}>
+      <Text style={s.tableTitle}>{title}</Text>
+      <View style={s.tableHeader}>
+        {headers.map((h) => (
+          <Text key={h} style={s.headerCell}>{h}</Text>
+        ))}
+      </View>
+      {rows.map(([col1, col2, col3], i) => (
+        <View key={i} style={[s.tableRow, i % 2 === 0 && s.tableRowAlt]}>
+          <Text style={s.cell}>{col1}</Text>
+          <Text style={[s.cell, s.cellRight]}>{col2}</Text>
+          <Text style={[s.cell, s.cellRight]}>{col3}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function CostBar({ items, total }: { items: Array<{ label: string; value: number }>; total: number }) {
+  if (items.length === 0 || total === 0) return null;
+
+  return (
+    <View style={s.barContainer}>
+      <View style={s.barTrack}>
+        {items.map((item, i) => {
+          const pct = (item.value / total) * 100;
+          if (pct < 1) return null;
+          return (
+            <View
+              key={i}
+              style={[
+                s.barSegment,
+                { width: `${pct}%` as unknown as number },
+                { backgroundColor: barColors[i % barColors.length] },
+              ]}
+            />
+          );
+        })}
+      </View>
+      <View style={s.barLegend}>
+        {items.filter((item) => item.value > 0).map((item, i) => (
+          <View key={i} style={s.legendItem}>
+            <View
+              style={[s.legendDot, { backgroundColor: barColors[i % barColors.length] }]}
+            />
+            <Text style={s.legendLabel}>
+              {item.label} ({fmtUsd(item.value)})
+            </Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const barColors = [C.brand, C.success, C.info, C.warning, C.error, C.textTertiary];
+
+export function CostsView({ dashboard }: CostsViewProps) {
+  const costs = dashboard?.costs;
+
+  if (!costs || (costs.totalAgents === 0 && costs.byPeriod.length === 0)) {
+    return (
+      <View style={s.emptyState}>
+        <Text style={s.emptyIcon}>$</Text>
+        <Text style={s.emptyTitle}>No cost data yet</Text>
+        <Text style={s.emptySubtitle}>
+          Agent costs appear here once agents report their usage.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={s.container}>
+      <AlertBanner alerts={costs.alerts} />
+      <SummaryCards totalCost={costs.totalCostUsd} totalAgents={costs.totalAgents} />
+
+      <CostBar
+        items={costs.byWorkstream.map((w) => ({ label: w.workstream, value: w.costUsd }))}
+        total={costs.totalCostUsd}
+      />
+
+      <View style={s.tablesRow}>
+        <CostTable
+          title="Cost by Day"
+          headers={['Date', 'Cost', 'Agents']}
+          rows={costs.byPeriod.slice(-14).map((p) => [
+            p.period,
+            fmtUsd(p.costUsd),
+            String(p.agentCount),
+          ])}
+        />
+        <CostTable
+          title="Cost by Workstream"
+          headers={['Workstream', 'Cost', 'Agents']}
+          rows={costs.byWorkstream.map((w) => [
+            w.workstream,
+            fmtUsd(w.costUsd),
+            String(w.agentCount),
+          ])}
+        />
+      </View>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+const s = StyleSheet.create({
+  container: { flex: 1, gap: 20 },
+
+  // Alerts
+  alertContainer: { gap: 8 },
+  alertRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    padding: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  alertCritical: {
+    backgroundColor: `${C.error}18` as unknown as object,
+    borderColor: C.error,
+  },
+  alertWarning: {
+    backgroundColor: `${C.warning}18` as unknown as object,
+    borderColor: C.warning,
+  },
+  alertIcon: { fontSize: 14, fontWeight: '700', color: C.error },
+  alertText: { ...T.bodySm, color: C.textPrimary, flex: 1 },
+
+  // Stats bar
+  statsBar: {
+    flexDirection: 'row',
+    gap: 10,
+    flexWrap: 'wrap' as const,
+  },
+  statCard: {
+    flex: 1,
+    minWidth: 120,
+    backgroundColor: C.surface1,
+    borderWidth: 1,
+    borderColor: C.border,
+    borderRadius: 8,
+    padding: 14,
+  },
+  statLabel: {
+    fontSize: 10,
+    color: C.textTertiary,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: 6,
+  },
+  statValue: { ...T.heading2xl },
+
+  // Cost bar visualization
+  barContainer: { gap: 8 },
+  barTrack: {
+    flexDirection: 'row',
+    height: 20,
+    borderRadius: 4,
+    overflow: 'hidden',
+    backgroundColor: C.surface1,
+  },
+  barSegment: { height: '100%' as unknown as number },
+  barLegend: {
+    flexDirection: 'row',
+    flexWrap: 'wrap' as const,
+    gap: 12,
+  },
+  legendItem: { flexDirection: 'row', alignItems: 'center', gap: 4 },
+  legendDot: { width: 8, height: 8, borderRadius: 4 },
+  legendLabel: { ...T.bodySm, color: C.textSecondary },
+
+  // Tables
+  tablesRow: {
+    flexDirection: 'row',
+    gap: 16,
+    flexWrap: 'wrap' as const,
+  },
+  tableContainer: {
+    flex: 1,
+    minWidth: 280,
+    backgroundColor: C.surface1,
+    borderWidth: 1,
+    borderColor: C.border,
+    borderRadius: 8,
+    padding: 16,
+  },
+  tableTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: C.textPrimary,
+    marginBottom: 12,
+    fontFamily: "'Space Grotesk', sans-serif",
+  },
+  tableHeader: {
+    flexDirection: 'row',
+    borderBottomWidth: 1,
+    borderBottomColor: C.border,
+    paddingBottom: 8,
+    marginBottom: 4,
+  },
+  headerCell: {
+    flex: 1,
+    fontSize: 10,
+    color: C.textTertiary,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  tableRow: {
+    flexDirection: 'row',
+    paddingVertical: 6,
+  },
+  tableRowAlt: {
+    backgroundColor: `${C.surface2}60` as unknown as object,
+    borderRadius: 4,
+  },
+  cell: { flex: 1, ...T.bodySm, color: C.textSecondary },
+  cellRight: { textAlign: 'right' },
+
+  emptyText: { ...T.bodySm, color: C.textTertiary },
+
+  // Empty state
+  emptyState: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingTop: 80,
+    gap: 8,
+  },
+  emptyIcon: { fontSize: 48, color: C.textTertiary },
+  emptyTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: C.textSecondary,
+    fontFamily: "'Space Grotesk', sans-serif",
+  },
+  emptySubtitle: {
+    fontSize: 13,
+    color: C.textTertiary,
+    textAlign: 'center',
+    maxWidth: 360,
+  },
+});

--- a/src/dashboard/views/CostsView.tsx
+++ b/src/dashboard/views/CostsView.tsx
@@ -93,31 +93,28 @@ function CostTable({
 
 function CostBar({ items, total }: { items: Array<{ label: string; value: number }>; total: number }) {
   if (items.length === 0 || total === 0) return null;
+  const visible = items
+    .map((item, i) => ({ ...item, color: barColors[i % barColors.length], pct: (item.value / total) * 100 }))
+    .filter((item) => item.value > 0);
 
   return (
     <View style={s.barContainer}>
       <View style={s.barTrack}>
-        {items.map((item, i) => {
-          const pct = (item.value / total) * 100;
-          if (pct < 1) return null;
-          return (
-            <View
-              key={i}
-              style={[
-                s.barSegment,
-                { width: `${pct}%` as unknown as number },
-                { backgroundColor: barColors[i % barColors.length] },
-              ]}
-            />
-          );
-        })}
+        {visible.filter((v) => v.pct >= 1).map((item, i) => (
+          <View
+            key={i}
+            style={[
+              s.barSegment,
+              { width: `${item.pct}%` as unknown as number },
+              { backgroundColor: item.color },
+            ]}
+          />
+        ))}
       </View>
       <View style={s.barLegend}>
-        {items.filter((item) => item.value > 0).map((item, i) => (
+        {visible.map((item, i) => (
           <View key={i} style={s.legendItem}>
-            <View
-              style={[s.legendDot, { backgroundColor: barColors[i % barColors.length] }]}
-            />
+            <View style={[s.legendDot, { backgroundColor: item.color }]} />
             <Text style={s.legendLabel}>
               {item.label} ({fmtUsd(item.value)})
             </Text>

--- a/src/modules/agents/commands.ts
+++ b/src/modules/agents/commands.ts
@@ -7,6 +7,14 @@ import { buildAgentDispatchContext, formatDispatchBrief } from './dispatch-conte
 import { updateTaskStatus } from '../pm/data/task-ops.js';
 import { migrateAoAgents } from './migrate-ao.js';
 import type { AgentArtifacts } from './agent-done-handler.js';
+import {
+  getAgentCostEntries,
+  summarizeCosts,
+  aggregateByPeriod,
+  aggregateByWorkstream,
+  checkBudgetAlerts,
+  loadBudgetThresholds,
+} from './cost-aggregation.js';
 
 function padRight(s: string, len: number): string {
   return s.length >= len ? s.substring(0, len) : s + ' '.repeat(len - s.length);
@@ -330,7 +338,92 @@ export function createAgentCommands(): Command {
       });
     });
 
+  // brain agent costs
+  cmd
+    .command('costs')
+    .description('Show agent cost aggregation and budget alerts')
+    .option('--since <date>', 'Start date (ISO format, e.g. 2026-04-01)')
+    .option('--until <date>', 'End date (ISO format)')
+    .option('--period <granularity>', 'Group by day or week', 'day')
+    .option('--by-workstream', 'Group costs by workstream')
+    .option('--json', 'Output JSON')
+    .action(async (opts) => {
+      await withDb((svc) => {
+        const rawDb = (svc as unknown as { db: { db?: unknown } }).db;
+        const innerDb = (rawDb as { db?: unknown }).db ?? rawDb;
+        const entries = getAgentCostEntries(innerDb, {
+          since: opts.since,
+          until: opts.until,
+        });
+        const summary = summarizeCosts(entries);
+        const thresholds = loadBudgetThresholds();
+        const alerts = checkBudgetAlerts(entries, thresholds);
+
+        if (opts.json) {
+          const result: Record<string, unknown> = { summary };
+          if (opts.byWorkstream) {
+            result.byWorkstream = aggregateByWorkstream(entries);
+          } else {
+            result.byPeriod = aggregateByPeriod(entries, opts.period as 'day' | 'week');
+          }
+          if (alerts.length > 0) result.alerts = alerts;
+          process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+          return;
+        }
+
+        // Budget alerts
+        for (const alert of alerts) {
+          const icon = alert.level === 'critical' ? '!!' : '!';
+          process.stderr.write(`[${icon} ${alert.level.toUpperCase()}] ${alert.message}\n`);
+        }
+
+        // Summary header
+        process.stdout.write(
+          `Total: $${summary.totalCostUsd.toFixed(2)} | ` +
+            `${summary.agentCount} agents | ` +
+            `${fmtTokens(summary.totalTokensInput)}in / ${fmtTokens(summary.totalTokensOutput)}out\n\n`
+        );
+
+        if (opts.byWorkstream) {
+          const rows = aggregateByWorkstream(entries);
+          formatCostTable(
+            ['Workstream', 'Cost', 'Agents'],
+            rows.map((r) => [r.workstream, `$${r.costUsd.toFixed(2)}`, String(r.agentCount)])
+          );
+        } else {
+          const rows = aggregateByPeriod(entries, opts.period as 'day' | 'week');
+          formatCostTable(
+            ['Period', 'Cost', 'Agents'],
+            rows.map((r) => [r.period, `$${r.costUsd.toFixed(2)}`, String(r.agentCount)])
+          );
+        }
+      });
+    });
+
   cmd.addCommand(createWorktreeCommand());
 
   return cmd;
+}
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M `;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K `;
+  return `${n} `;
+}
+
+function formatCostTable(headers: string[], rows: string[][]): void {
+  if (rows.length === 0) {
+    process.stdout.write('No cost data found.\n');
+    return;
+  }
+
+  const widths = headers.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i].length)));
+
+  const header = headers.map((h, i) => padRight(h, widths[i])).join('  ');
+  const separator = widths.map((w) => '-'.repeat(w)).join('  ');
+  process.stdout.write(header + '\n' + separator + '\n');
+
+  for (const row of rows) {
+    process.stdout.write(row.map((c, i) => padRight(c, widths[i])).join('  ') + '\n');
+  }
 }

--- a/src/modules/agents/commands.ts
+++ b/src/modules/agents/commands.ts
@@ -1,5 +1,6 @@
 import { Command } from '@commander-js/extra-typings';
 import { withBrain, withDb } from '../../services/brain-service.js';
+import { getRawDb } from '../../utils/db.js';
 import { createAgent, getAgent, listAgents, updateAgentStatus, getAgentContext } from './data.js';
 import type { AgentRecord } from './types.js';
 import { createWorktreeCommand } from './worktree-commands.js';
@@ -349,8 +350,7 @@ export function createAgentCommands(): Command {
     .option('--json', 'Output JSON')
     .action(async (opts) => {
       await withDb((svc) => {
-        const rawDb = (svc as unknown as { db: { db?: unknown } }).db;
-        const innerDb = (rawDb as { db?: unknown }).db ?? rawDb;
+        const innerDb = getRawDb(svc.db);
         const entries = getAgentCostEntries(innerDb, {
           since: opts.since,
           until: opts.until,

--- a/src/modules/agents/cost-aggregation.ts
+++ b/src/modules/agents/cost-aggregation.ts
@@ -1,0 +1,241 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { AgentRecord } from './types.js';
+import { listAgents, getAgentContext } from './data.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AgentCostEntry {
+  agentId: string;
+  name: string;
+  task: string | null;
+  status: string;
+  costUsd: number;
+  durationMs: number;
+  tokensInput: number;
+  tokensOutput: number;
+  createdAt: string;
+  completedAt: string | null;
+}
+
+export interface CostSummary {
+  totalCostUsd: number;
+  totalDurationMs: number;
+  totalTokensInput: number;
+  totalTokensOutput: number;
+  agentCount: number;
+  entries: AgentCostEntry[];
+}
+
+export interface CostByPeriod {
+  period: string;
+  costUsd: number;
+  agentCount: number;
+}
+
+export interface CostByWorkstream {
+  workstream: string;
+  costUsd: number;
+  agentCount: number;
+}
+
+export interface BudgetAlert {
+  level: 'info' | 'warning' | 'critical';
+  message: string;
+  currentSpend: number;
+  threshold: number;
+  period: string;
+}
+
+export interface BudgetThresholds {
+  dailyWarnUsd?: number;
+  dailyCriticalUsd?: number;
+  weeklyWarnUsd?: number;
+  weeklyCriticalUsd?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Data extraction
+// ---------------------------------------------------------------------------
+
+function extractCostEntry(db: unknown, agent: AgentRecord): AgentCostEntry {
+  const claudeResult = getAgentContext(db, agent.id, 'claude_result') as
+    | { total_cost_usd?: number; duration_ms?: number }
+    | undefined;
+  const tokensIn = (getAgentContext(db, agent.id, 'tokens_input') as number) ?? 0;
+  const tokensOut = (getAgentContext(db, agent.id, 'tokens_output') as number) ?? 0;
+
+  return {
+    agentId: agent.id,
+    name: agent.name,
+    task: agent.brain_task,
+    status: agent.status,
+    costUsd: claudeResult?.total_cost_usd ?? 0,
+    durationMs: claudeResult?.duration_ms ?? 0,
+    tokensInput: tokensIn,
+    tokensOutput: tokensOut,
+    createdAt: agent.created_at,
+    completedAt: agent.completed_at ?? null,
+  };
+}
+
+/** Load cost entries for all agents, optionally filtered by date range. */
+export function getAgentCostEntries(
+  db: unknown,
+  opts?: { since?: string; until?: string }
+): AgentCostEntry[] {
+  const agents = listAgents(db);
+  const entries = agents.map((a) => extractCostEntry(db, a));
+
+  return entries.filter((e) => {
+    if (opts?.since && e.createdAt < opts.since) return false;
+    if (opts?.until && e.createdAt > opts.until) return false;
+    return true;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation
+// ---------------------------------------------------------------------------
+
+export function summarizeCosts(entries: AgentCostEntry[]): CostSummary {
+  return {
+    totalCostUsd: entries.reduce((s, e) => s + e.costUsd, 0),
+    totalDurationMs: entries.reduce((s, e) => s + e.durationMs, 0),
+    totalTokensInput: entries.reduce((s, e) => s + e.tokensInput, 0),
+    totalTokensOutput: entries.reduce((s, e) => s + e.tokensOutput, 0),
+    agentCount: entries.length,
+    entries,
+  };
+}
+
+function dateKey(iso: string, granularity: 'day' | 'week'): string {
+  const d = new Date(iso);
+  if (granularity === 'day') {
+    return d.toISOString().slice(0, 10);
+  }
+  // ISO week: Monday-based
+  const day = d.getDay();
+  const diff = d.getDate() - day + (day === 0 ? -6 : 1);
+  const monday = new Date(d);
+  monday.setDate(diff);
+  return `W${monday.toISOString().slice(0, 10)}`;
+}
+
+export function aggregateByPeriod(
+  entries: AgentCostEntry[],
+  granularity: 'day' | 'week' = 'day'
+): CostByPeriod[] {
+  const map = new Map<string, { costUsd: number; agentCount: number }>();
+
+  for (const e of entries) {
+    const key = dateKey(e.createdAt, granularity);
+    const existing = map.get(key) ?? { costUsd: 0, agentCount: 0 };
+    existing.costUsd += e.costUsd;
+    existing.agentCount += 1;
+    map.set(key, existing);
+  }
+
+  return [...map.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([period, data]) => ({ period, ...data }));
+}
+
+export function aggregateByWorkstream(entries: AgentCostEntry[]): CostByWorkstream[] {
+  const map = new Map<string, { costUsd: number; agentCount: number }>();
+
+  for (const e of entries) {
+    const ws = extractWorkstream(e.task);
+    const existing = map.get(ws) ?? { costUsd: 0, agentCount: 0 };
+    existing.costUsd += e.costUsd;
+    existing.agentCount += 1;
+    map.set(ws, existing);
+  }
+
+  return [...map.entries()]
+    .sort(([, a], [, b]) => b.costUsd - a.costUsd)
+    .map(([workstream, data]) => ({ workstream, ...data }));
+}
+
+function extractWorkstream(task: string | null): string {
+  if (!task) return '(unassigned)';
+  // Task IDs like "VNM-45.28" -> workstream "VNM-45"
+  const match = task.match(/^([A-Z]+-\d+)\./);
+  return match ? match[1] : task;
+}
+
+// ---------------------------------------------------------------------------
+// Budget alerts
+// ---------------------------------------------------------------------------
+
+export function checkBudgetAlerts(
+  entries: AgentCostEntry[],
+  thresholds: BudgetThresholds
+): BudgetAlert[] {
+  const alerts: BudgetAlert[] = [];
+  const now = new Date();
+
+  const todayStart = new Date(now);
+  todayStart.setHours(0, 0, 0, 0);
+  const todayEntries = entries.filter((e) => new Date(e.createdAt) >= todayStart);
+  const dailySpend = todayEntries.reduce((s, e) => s + e.costUsd, 0);
+
+  const weekStart = new Date(now);
+  weekStart.setDate(weekStart.getDate() - weekStart.getDay() + 1);
+  weekStart.setHours(0, 0, 0, 0);
+  const weekEntries = entries.filter((e) => new Date(e.createdAt) >= weekStart);
+  const weeklySpend = weekEntries.reduce((s, e) => s + e.costUsd, 0);
+
+  if (thresholds.dailyCriticalUsd && dailySpend >= thresholds.dailyCriticalUsd) {
+    alerts.push({
+      level: 'critical',
+      message: `Daily spend $${dailySpend.toFixed(2)} exceeds critical threshold $${thresholds.dailyCriticalUsd.toFixed(2)}`,
+      currentSpend: dailySpend,
+      threshold: thresholds.dailyCriticalUsd,
+      period: 'daily',
+    });
+  } else if (thresholds.dailyWarnUsd && dailySpend >= thresholds.dailyWarnUsd) {
+    alerts.push({
+      level: 'warning',
+      message: `Daily spend $${dailySpend.toFixed(2)} exceeds warning threshold $${thresholds.dailyWarnUsd.toFixed(2)}`,
+      currentSpend: dailySpend,
+      threshold: thresholds.dailyWarnUsd,
+      period: 'daily',
+    });
+  }
+
+  if (thresholds.weeklyCriticalUsd && weeklySpend >= thresholds.weeklyCriticalUsd) {
+    alerts.push({
+      level: 'critical',
+      message: `Weekly spend $${weeklySpend.toFixed(2)} exceeds critical threshold $${thresholds.weeklyCriticalUsd.toFixed(2)}`,
+      currentSpend: weeklySpend,
+      threshold: thresholds.weeklyCriticalUsd,
+      period: 'weekly',
+    });
+  } else if (thresholds.weeklyWarnUsd && weeklySpend >= thresholds.weeklyWarnUsd) {
+    alerts.push({
+      level: 'warning',
+      message: `Weekly spend $${weeklySpend.toFixed(2)} exceeds warning threshold $${thresholds.weeklyWarnUsd.toFixed(2)}`,
+      currentSpend: weeklySpend,
+      threshold: thresholds.weeklyWarnUsd,
+      period: 'weekly',
+    });
+  }
+
+  return alerts;
+}
+
+/** Load budget thresholds from ao.config.json. */
+export function loadBudgetThresholds(cwd?: string): BudgetThresholds {
+  const configPath = join(cwd ?? process.cwd(), 'ao.config.json');
+
+  try {
+    const raw = JSON.parse(readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+    const budget = raw.budgetAlerts as BudgetThresholds | undefined;
+    return budget ?? {};
+  } catch {
+    return {};
+  }
+}

--- a/src/modules/agents/cost-aggregation.ts
+++ b/src/modules/agents/cost-aggregation.ts
@@ -91,7 +91,11 @@ export function getAgentCostEntries(
 
   return entries.filter((e) => {
     if (opts?.since && e.createdAt < opts.since) return false;
-    if (opts?.until && e.createdAt > opts.until) return false;
+    if (opts?.until) {
+      // If until is date-only (YYYY-MM-DD), include the entire day
+      const bound = opts.until.length === 10 ? opts.until + 'T23:59:59.999Z' : opts.until;
+      if (e.createdAt > bound) return false;
+    }
     return true;
   });
 }
@@ -183,7 +187,8 @@ export function checkBudgetAlerts(
   const dailySpend = todayEntries.reduce((s, e) => s + e.costUsd, 0);
 
   const weekStart = new Date(now);
-  weekStart.setDate(weekStart.getDate() - weekStart.getDay() + 1);
+  const dow = weekStart.getDay();
+  weekStart.setDate(weekStart.getDate() - dow + (dow === 0 ? -6 : 1));
   weekStart.setHours(0, 0, 0, 0);
   const weekEntries = entries.filter((e) => new Date(e.createdAt) >= weekStart);
   const weeklySpend = weekEntries.reduce((s, e) => s + e.costUsd, 0);

--- a/src/modules/agents/dispatch-loop.ts
+++ b/src/modules/agents/dispatch-loop.ts
@@ -7,6 +7,7 @@ import { countActiveAgents, getAgent } from './data.js';
 import { getDeliveryForTask, initiateDelivery } from './delivery.js';
 import { releaseWorktree } from './worktree.js';
 import { monitorDelivery } from './delivery-monitor.js';
+import { reviewWave, type WaveReviewResult } from './wave-review.js';
 
 const AGENT_POLL_INTERVAL = 5_000; // 5s
 const WIP_POLL_INTERVAL = 10_000; // 10s
@@ -20,6 +21,11 @@ export interface SpawnResult {
   agentId: string;
   taskId: string;
   branch?: string;
+}
+
+export interface WaveExecutionResult {
+  settled: PromiseSettledResult<void>[];
+  review: WaveReviewResult;
 }
 
 /** Inject the spawn function to avoid circular server ↔ modules dependency. */
@@ -149,9 +155,12 @@ export class DispatchLoop {
   /**
    * Execute all tasks in a wave with a sliding window that respects the WIP limit.
    * Launches up to N tasks concurrently, waits for one to finish before launching
-   * the next. Resolves only when all tasks in the wave are complete.
+   * the next. After all tasks complete, runs a post-wave review to detect
+   * file-level conflicts and validate the merged view with typecheck/lint.
+   *
+   * When `review.hasConflicts` is true, the caller should pause before the next wave.
    */
-  async executeWave(wave: WaveAssignment): Promise<PromiseSettledResult<void>[]> {
+  async executeWave(wave: WaveAssignment): Promise<WaveExecutionResult> {
     const { effectiveWip } = this.backpressure.computeEffectiveWip();
     const allPromises: Promise<void>[] = [];
     let inflight = 0;
@@ -169,6 +178,11 @@ export class DispatchLoop {
       inflight++;
     }
 
-    return Promise.allSettled(allPromises);
+    const settled = await Promise.allSettled(allPromises);
+
+    const review = reviewWave(this.rawDb, wave.wave, wave.taskIds, this.projectDir);
+    process.stderr.write(`[dispatch-loop] wave ${wave.wave} review:\n${review.summary}\n`);
+
+    return { settled, review };
   }
 }

--- a/src/modules/agents/dispatch-loop.ts
+++ b/src/modules/agents/dispatch-loop.ts
@@ -161,13 +161,14 @@ export class DispatchLoop {
    * When `review.hasConflicts` is true, the caller should pause before the next wave.
    */
   async executeWave(wave: WaveAssignment): Promise<WaveExecutionResult> {
-    const { effectiveWip } = this.backpressure.computeEffectiveWip();
     const allPromises: Promise<void>[] = [];
     let inflight = 0;
 
     for (const taskId of wave.taskIds) {
+      const { effectiveWip } = this.backpressure.computeEffectiveWip();
       while (inflight >= effectiveWip) {
         await this.waitForWipSlot();
+        inflight = countActiveAgents(this.rawDb);
       }
 
       const p = this.dispatchAndDeliver(taskId).finally(() => {

--- a/src/modules/agents/dispatch-loop.ts
+++ b/src/modules/agents/dispatch-loop.ts
@@ -168,7 +168,6 @@ export class DispatchLoop {
     for (const taskId of wave.taskIds) {
       while (inflight >= effectiveWip) {
         await this.waitForWipSlot();
-        inflight = countActiveAgents(this.rawDb);
       }
 
       const p = this.dispatchAndDeliver(taskId).finally(() => {

--- a/src/modules/agents/worktree.ts
+++ b/src/modules/agents/worktree.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { cpSync, existsSync } from 'node:fs';
 import { dirname, resolve, sep } from 'node:path';
 import {
   allocateWorktree as dbAllocate,
@@ -97,6 +97,13 @@ export function allocateWorktree(
     encoding: 'utf-8',
     stdio: 'pipe',
   });
+
+  // Copy .claude/ settings so hooks (agent-done, session capture) fire in worktrees
+  const claudeDir = resolve(projectRoot, '.claude');
+  const targetClaudeDir = resolve(worktreePath, '.claude');
+  if (existsSync(claudeDir) && !existsSync(targetClaudeDir)) {
+    cpSync(claudeDir, targetClaudeDir, { recursive: true });
+  }
 
   const input: AllocateWorktreeInput = {
     task_id: opts.taskId,

--- a/src/modules/autoloop/engine/consolidation-loop.ts
+++ b/src/modules/autoloop/engine/consolidation-loop.ts
@@ -2,11 +2,13 @@ import type { BrainDB } from '../../../services/brain-db.js';
 import type { BrainConfig, Embedder } from '../../../types.js';
 import type { AutoloopReport, AutoloopBounds } from '../types.js';
 import type { DedupScanResult } from './dedup-scanner.js';
+import type { EnrichmentSuggestion } from './task-enricher.js';
 import { checkBounds, createCounters, loadBounds } from './bounds.js';
 import { scanTaskQuality } from './quality-scanner.js';
 import { enrichUnderSpecifiedTasks } from './task-enricher.js';
 import { scanForDuplicates } from './dedup-scanner.js';
 import { recordAutoloopRun } from './run-tracker.js';
+import { writeEnrichmentToTask } from './enrichment-writer.js';
 
 export interface ConsolidationLoopOptions {
   bounds?: Partial<AutoloopBounds>;
@@ -54,6 +56,17 @@ export async function runTaskConsolidationLoop(
       );
       tasksEnriched = enrichment.tasksEnriched;
       counters.taskModifications += tasksEnriched;
+
+      // Write enrichment suggestions back to task descriptions
+      for (const suggestion of enrichment.suggestions) {
+        try {
+          await applyEnrichment(db, embedder, suggestion);
+        } catch (err) {
+          errors.push(
+            `Write-back ${suggestion.taskId}: ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+      }
     } catch (err) {
       errors.push(`Enrichment: ${err instanceof Error ? err.message : String(err)}`);
     }
@@ -90,6 +103,17 @@ export async function runTaskConsolidationLoop(
   recordAutoloopRun(db, report);
 
   return report;
+}
+
+async function applyEnrichment(
+  db: BrainDB,
+  embedder: Embedder,
+  suggestion: EnrichmentSuggestion
+): Promise<void> {
+  if (suggestion.suggestedAdditions.length === 0 && suggestion.relatedResearch.length === 0) {
+    return;
+  }
+  await writeEnrichmentToTask(db, embedder, suggestion);
 }
 
 function buildReport(

--- a/src/modules/autoloop/engine/enrichment-writer.ts
+++ b/src/modules/autoloop/engine/enrichment-writer.ts
@@ -1,0 +1,68 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import type { BrainDB } from '../../../services/brain-db.js';
+import type { Embedder } from '../../../types.js';
+import { indexSingleFile } from '../../../services/indexing.js';
+import { getPmNotes } from '../../pm/data/queries.js';
+import type { EnrichmentSuggestion } from './task-enricher.js';
+
+/**
+ * Writes enrichment suggestions back to a task's markdown body
+ * by appending an "Enrichment Context" section.
+ */
+export async function writeEnrichmentToTask(
+  db: BrainDB,
+  embedder: Embedder,
+  suggestion: EnrichmentSuggestion
+): Promise<void> {
+  const notes = getPmNotes(db, 'task', { display_id: suggestion.taskId });
+  if (notes.length === 0) return;
+
+  const note = notes[0];
+  if (!existsSync(note.filePath)) return;
+
+  let content = readFileSync(note.filePath, 'utf-8');
+
+  // Don't re-enrich if already enriched
+  if (content.includes('## Enrichment Context')) return;
+
+  const section = buildEnrichmentSection(suggestion);
+  if (!section) return;
+
+  content = appendSection(content, section);
+  writeFileSync(note.filePath, content, 'utf-8');
+
+  const hash = createHash('sha256').update(content).digest('hex');
+  await indexSingleFile(db, embedder, note.filePath, content, hash, Date.now());
+}
+
+function buildEnrichmentSection(suggestion: EnrichmentSuggestion): string | null {
+  const lines: string[] = [];
+
+  if (suggestion.relatedResearch.length > 0) {
+    lines.push('### Related Research');
+    for (const r of suggestion.relatedResearch) {
+      lines.push(`- **${r.title}** (relevance: ${r.relevance.toFixed(2)})`);
+      if (r.excerpt) {
+        lines.push(`  > ${r.excerpt.slice(0, 200)}`);
+      }
+    }
+    lines.push('');
+  }
+
+  if (suggestion.relatedMemories.length > 0) {
+    lines.push('### Related Memories');
+    for (const m of suggestion.relatedMemories) {
+      lines.push(`- ${m}`);
+    }
+    lines.push('');
+  }
+
+  if (lines.length === 0) return null;
+
+  return ['', '## Enrichment Context', '', ...lines].join('\n');
+}
+
+function appendSection(content: string, section: string): string {
+  return content.trimEnd() + '\n' + section + '\n';
+}

--- a/src/modules/autoloop/engine/quality-scanner.ts
+++ b/src/modules/autoloop/engine/quality-scanner.ts
@@ -67,6 +67,7 @@ export function scoreTask(task: {
   display_id: string;
   title?: string;
   description?: string;
+  category?: string;
   depends_on?: string[];
   done_when?: string;
   acceptance_criteria?: string[];
@@ -126,6 +127,9 @@ export function scoreTask(task: {
 
   return {
     taskId: task.display_id,
+    title: task.title ?? '',
+    description: task.description ?? '',
+    category: task.category ?? '',
     overall,
     dimensions,
     suggestions,

--- a/src/modules/autoloop/engine/task-enricher.ts
+++ b/src/modules/autoloop/engine/task-enricher.ts
@@ -1,13 +1,20 @@
 import type { BrainDB } from '../../../services/brain-db.js';
 import type { Embedder } from '../../../types.js';
-import { search } from '../../../services/search.js';
+import { search, searchMemories } from '../../../services/search.js';
 import type { TaskReadinessScore } from '../types.js';
+
+export interface RelatedResearchEntry {
+  title: string;
+  noteId: string;
+  relevance: number;
+  excerpt: string;
+}
 
 export interface EnrichmentSuggestion {
   taskId: string;
   currentDescription: string;
   suggestedAdditions: string[];
-  relatedResearch: Array<{ title: string; noteId: string; relevance: number }>;
+  relatedResearch: RelatedResearchEntry[];
   relatedMemories: string[];
 }
 
@@ -47,34 +54,45 @@ export async function enrichUnderSpecifiedTasks(
   };
 }
 
+function buildSearchQuery(task: TaskReadinessScore): string {
+  const parts: string[] = [];
+  if (task.title) parts.push(task.title);
+  if (task.description) parts.push(task.description.slice(0, 200));
+  if (task.category) parts.push(task.category);
+  return parts.join(' ').trim() || task.taskId;
+}
+
 async function enrichTask(
   db: BrainDB,
   embedder: Embedder,
   task: TaskReadinessScore,
   minRelevance: number
 ): Promise<EnrichmentSuggestion> {
-  const taskTitle = task.taskId;
-  const currentDescription = '';
+  const query = buildSearchQuery(task);
 
-  // Search for related research using the task ID as query
-  const searchResult = await search(db, embedder, taskTitle, {
+  // Search for related research notes
+  const searchResult = await search(db, embedder, query, {
     limit: 5,
     tier: 'slow',
   });
 
-  const relatedResearch = searchResult.results
+  const relatedResearch: RelatedResearchEntry[] = searchResult.results
     .filter((r) => r.score >= minRelevance)
-    .filter((r) => {
-      // Prefer research notes by checking tags
-      return r.tags.some(
+    .filter((r) =>
+      r.tags.some(
         (t) => t.includes('research') || t.includes('synthesis') || t.includes('competitive')
-      );
-    })
+      )
+    )
     .map((r) => ({
       title: r.heading ?? r.noteId,
       noteId: r.noteId,
       relevance: r.score,
+      excerpt: r.excerpt.slice(0, 300),
     }));
+
+  // Search memories for relevant context
+  const memoryResults = await searchMemories(db, embedder, query, 5);
+  const relatedMemories = memoryResults.filter((m) => m.score >= minRelevance).map((m) => m.memory);
 
   const suggestedAdditions: string[] = [];
 
@@ -83,7 +101,7 @@ async function enrichTask(
   }
 
   if (!task.dimensions.hasRelatedResearch && relatedResearch.length > 0) {
-    const refs = relatedResearch.map((r) => r.title).join(', ');
+    const refs = relatedResearch.map((r) => `${r.title} (${r.excerpt.slice(0, 80)}…)`).join('; ');
     suggestedAdditions.push(`Related research found: ${refs}`);
   }
 
@@ -91,12 +109,13 @@ async function enrichTask(
     suggestedAdditions.push('Add acceptance criteria or done-when definition');
   }
 
-  // Search memories for relevant context
-  const relatedMemories: string[] = [];
+  if (relatedMemories.length > 0) {
+    suggestedAdditions.push(`Relevant memories: ${relatedMemories.join('; ')}`);
+  }
 
   return {
     taskId: task.taskId,
-    currentDescription,
+    currentDescription: task.description,
     suggestedAdditions,
     relatedResearch,
     relatedMemories,

--- a/src/modules/autoloop/types.ts
+++ b/src/modules/autoloop/types.ts
@@ -60,6 +60,9 @@ export interface AutoloopInsight {
 /** Task readiness assessment from consolidation loop */
 export interface TaskReadinessScore {
   taskId: string;
+  title: string;
+  description: string;
+  category: string;
   overall: number;
   dimensions: {
     hasDescription: boolean;

--- a/src/server/dispatch.ts
+++ b/src/server/dispatch.ts
@@ -47,6 +47,7 @@ export interface DispatchOptions {
   maxBudgetUsd?: number;
   dryRun?: boolean;
   promptOverride?: string;
+  worktreeBudget?: number;
 }
 
 export interface DispatchResult {
@@ -106,7 +107,14 @@ export async function dispatchTask(
     return { taskId, prompt, routing, model, dryRun: true as const };
   }
 
-  const worktreeResult = maybeAllocateWorktree(svc.db, projectDir, routing, taskId, pullResult);
+  const worktreeResult = maybeAllocateWorktree(
+    svc.db,
+    projectDir,
+    routing,
+    taskId,
+    pullResult,
+    opts.worktreeBudget
+  );
 
   const agentId = createAgent(svc.db, {
     name: workerDispatch?.description || `headless-${taskId}`,
@@ -324,7 +332,8 @@ function maybeAllocateWorktree(
   projectDir: string,
   routing: RoutingResult,
   taskId: string,
-  pullResult: PullResult
+  pullResult: PullResult,
+  budget?: number
 ): AllocateWorktreeResult | undefined {
   if (routing.isolation === 'none') return undefined;
 
@@ -335,6 +344,7 @@ function maybeAllocateWorktree(
     taskId,
     workstream,
     claimToken: pullResult.claimToken,
+    budget,
   });
   if (result?.worktreePath && !existsSync(result.worktreePath)) {
     throw new Error(

--- a/src/server/orchestration.ts
+++ b/src/server/orchestration.ts
@@ -9,7 +9,7 @@ import { getDeliveryForTask, type DeliveryRecord } from '../modules/agents/deliv
 import { computeWaves } from '../modules/pm/engine/dependency.js';
 import { listTasks } from '../modules/pm/data/task-ops.js';
 import { DispatchLoop } from '../modules/agents/dispatch-loop.js';
-import { reviewWave, type WaveReviewResult } from '../modules/agents/wave-review.js';
+import type { WaveReviewResult } from '../modules/agents/wave-review.js';
 import { dispatchTask, resolveProjectDir, type DispatchResult } from './dispatch.js';
 
 /** Recovery statuses: deliveries that need a monitor restarted after process restart. */
@@ -140,12 +140,8 @@ export class OrchestrationService {
     );
     for (const wave of waves) {
       process.stderr.write(`[orchestration] wave ${wave.wave}: [${wave.taskIds.join(', ')}]\n`);
-      await loop.executeWave(wave);
-      process.stderr.write(`[orchestration] wave ${wave.wave} complete, reviewing...\n`);
-
-      const review = reviewWave(this.rawDb, wave.wave, wave.taskIds, projectDir);
+      const { review } = await loop.executeWave(wave);
       waveReviews.push(review);
-      process.stderr.write(`[orchestration] wave ${wave.wave} review:\n${review.summary}\n`);
 
       if (review.hasConflicts) {
         process.stderr.write(

--- a/src/server/orchestration.ts
+++ b/src/server/orchestration.ts
@@ -126,7 +126,8 @@ export class OrchestrationService {
       svc.db,
       this.backpressure,
       async (taskId) => {
-        const result = await dispatchTask(svc, { taskId });
+        const { effectiveWip } = this.backpressure.computeEffectiveWip();
+        const result = await dispatchTask(svc, { taskId, worktreeBudget: effectiveWip });
         const r = result as DispatchResult;
         return { agentId: r.agentId, taskId: r.taskId, branch: r.branch };
       },


### PR DESCRIPTION
## Summary

- **Agent output** (3 commits from VNM-45 dispatch runs): consolidation loop fixes, wave review integration, cost aggregation + dashboard view
- **Dispatch bug fixes**: WIP counter reset, worktree budget alignment with effective WIP, `.claude/` settings copy into worktrees for hook discovery, cost aggregation date/week boundary bugs, CostBar color mismatch

## Commits

1. `7b91dac` Fix consolidation loop: search query, description write-back, excerpts, memories
2. `df9265d` Integrate post-wave review into dispatch loop executeWave  
3. `ea36292` Add agent cost aggregation, budget alerts, and dashboard costs view
4. `93d5ea8` Fix dispatch bugs: WIP counter, worktree budget, cost aggregation, hook discovery

## Bugs fixed in review commit

- **WIP counter reset**: `executeWave` was re-reading stale DB value after `waitForWipSlot`, resetting the local inflight counter
- **Worktree budget < WIP**: default budget was 3 regardless of effective WIP; now threaded from backpressure controller
- **Hook discovery in worktrees**: `.claude/` directory now copied into worktrees at allocation time so agent-done and session capture hooks fire
- **`--until` same-day exclusion**: string comparison excluded entries from the target day
- **Sunday week boundary**: `checkBudgetAlerts` computed wrong Monday when `getDay() === 0`
- **CostBar legend colors**: filtering items < 1% after indexing caused legend/bar color mismatch

## Test plan

- [x] Typecheck passes
- [x] Lint passes
- [x] Full test suite: 87 files, 1,085 tests pass
- [x] New tests: Sunday week boundary regression, worktree `.claude` copy + skip
- [ ] Manual dispatch run to validate WIP + worktree budget alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)