### PR TITLE
Fix delivery pipeline, dashboard serving, and multi-session MCP

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "brain": {
       "command": "npx",
-      "args": ["tsx", "src/cli.ts", "serve", "--mcp"],
+      "args": ["tsx", "src/cli.ts", "serve", "--port", "7800"],
       "cwd": "/Users/hjewkes/Documents/projects/brain",
       "env": {
         "PATH": "/Users/hjewkes/.local/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin"

--- a/__tests__/modules/agents/dispatch-loop.test.ts
+++ b/__tests__/modules/agents/dispatch-loop.test.ts
@@ -148,10 +148,10 @@ describe('DispatchLoop', () => {
       expect(mockMonitorDelivery).not.toHaveBeenCalled();
     });
 
-    it('uses existing delivery record if agent-done hook already created one', async () => {
+    it('uses existing delivery record if agent-done hook already pushed', async () => {
       spawnFn.mockResolvedValue({ agentId: 'a1', taskId: 't1', branch: 'b1' });
       mockGetAgent.mockReturnValueOnce({ status: 'completed' });
-      const existing = { agent_id: 'a1', task_id: 't1', branch: 'b1' };
+      const existing = { agent_id: 'a1', task_id: 't1', branch: 'b1', status: 'pr-open' };
       mockGetDelivery.mockReturnValue(existing);
       mockMonitorDelivery.mockResolvedValue('merged');
 
@@ -159,6 +159,25 @@ describe('DispatchLoop', () => {
 
       expect(mockInitiateDelivery).not.toHaveBeenCalled();
       expect(mockMonitorDelivery).toHaveBeenCalledWith(fakeDb, existing, projectDir);
+    });
+
+    it('retries delivery when existing record has push-failed status', async () => {
+      spawnFn.mockResolvedValue({ agentId: 'a1', taskId: 't1', branch: 'b1' });
+      mockGetAgent.mockReturnValueOnce({ status: 'completed' });
+      mockGetDelivery.mockReturnValue({
+        agent_id: 'a1',
+        task_id: 't1',
+        branch: 'b1',
+        status: 'push-failed',
+      });
+      const retried = { agent_id: 'a1', task_id: 't1', branch: 'b1', status: 'pr-open' };
+      mockInitiateDelivery.mockReturnValue(retried);
+      mockMonitorDelivery.mockResolvedValue('merged');
+
+      await makeLoop().dispatchAndDeliver('t1');
+
+      expect(mockInitiateDelivery).toHaveBeenCalledWith(fakeDb, 'a1', 't1', 'b1', projectDir);
+      expect(mockMonitorDelivery).toHaveBeenCalledWith(fakeDb, retried, projectDir);
     });
 
     it('skips monitoring when no branch and no existing delivery', async () => {

--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -8,7 +8,11 @@ import type { HookEvent } from '../hooks/types.js';
 import { seekJsonlFile } from '../utils/jsonl-seek.js';
 
 const __dirname_esm = dirname(fileURLToPath(import.meta.url));
-const DASHBOARD_DIR = join(__dirname_esm, '..', '..', 'dist', 'dashboard');
+const DASHBOARD_DIR_RELATIVE = join(__dirname_esm, '..', '..', 'dist', 'dashboard');
+const DASHBOARD_DIR_CWD = join(process.cwd(), 'dist', 'dashboard');
+const DASHBOARD_DIR = existsSync(join(DASHBOARD_DIR_RELATIVE, 'index.html'))
+  ? DASHBOARD_DIR_RELATIVE
+  : DASHBOARD_DIR_CWD;
 
 export type SseClients = Set<ServerResponse>;
 

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -177,19 +177,34 @@ export async function startServeServer(resolveOpts?: ResolveOptions, port = 7800
 
   const sseClients: SseClients = new Set();
 
-  const httpServer = createServer(createHttpHandler(service, sseClients));
-  httpServer.listen(port, () => {
-    process.stderr.write(`Dashboard: http://localhost:${port}\n`);
-    process.stderr.write(`API: http://localhost:${port}/api/dashboard\n`);
-  });
+  let heartbeat: ReturnType<typeof setInterval> | undefined;
+  let httpServer: ReturnType<typeof createServer> | undefined;
 
-  const heartbeat = setInterval(() => {
-    broadcast(sseClients, 'heartbeat', { ts: Date.now() });
-  }, 30_000);
+  if (port > 0) {
+    httpServer = createServer(createHttpHandler(service, sseClients));
+    httpServer.on('error', (err: NodeJS.ErrnoException) => {
+      if (err.code === 'EADDRINUSE') {
+        process.stderr.write(
+          `Port ${port} in use — running MCP stdio only (dashboard served by another session)\n`
+        );
+        httpServer = undefined;
+      } else {
+        throw err;
+      }
+    });
+    httpServer.listen(port, () => {
+      process.stderr.write(`Dashboard: http://localhost:${port}\n`);
+      process.stderr.write(`API: http://localhost:${port}/api/dashboard\n`);
+    });
+
+    heartbeat = setInterval(() => {
+      broadcast(sseClients, 'heartbeat', { ts: Date.now() });
+    }, 30_000);
+  }
 
   const shutdown = () => {
-    clearInterval(heartbeat);
-    httpServer.close();
+    if (heartbeat) clearInterval(heartbeat);
+    if (httpServer) httpServer.close();
     service.close();
     process.exit(0);
   };

--- a/src/modules/agents/delivery.ts
+++ b/src/modules/agents/delivery.ts
@@ -134,7 +134,7 @@ export function pushBranch(branch: string, projectDir: string): void {
     cwd: projectDir,
     encoding: 'utf-8',
     stdio: 'pipe',
-    timeout: 10_000,
+    timeout: 60_000,
   });
 }
 

--- a/src/modules/agents/dispatch-loop.ts
+++ b/src/modules/agents/dispatch-loop.ts
@@ -89,14 +89,28 @@ export class DispatchLoop {
    * The agent-done-handler hook may have already done this; this is a fallback.
    * Returns the delivery record if available, null on failure.
    */
+  /** Terminal delivery statuses that don't need a retry. */
+  private static DELIVERED_STATUSES = new Set([
+    'pushed',
+    'pr-open',
+    'conflicted',
+    'merged',
+    'delivered',
+    'stalled',
+    'redispatched',
+  ]);
+
   private ensureDelivery(
     agentId: string,
     taskId: string,
     branch: string | undefined
   ): import('./delivery.js').DeliveryRecord | null {
     const existing = getDeliveryForTask(this.rawDb, taskId);
-    if (existing) return existing;
+    if (existing && DispatchLoop.DELIVERED_STATUSES.has(existing.status)) {
+      return existing;
+    }
 
+    // Failed or in-progress record from a prior attempt — retry delivery
     if (!branch) {
       process.stderr.write(`[dispatch-loop] no branch for ${taskId}, cannot initiate delivery\n`);
       return null;

--- a/src/modules/agents/dispatch-loop.ts
+++ b/src/modules/agents/dispatch-loop.ts
@@ -140,13 +140,15 @@ export class DispatchLoop {
 
     const delivery = this.ensureDelivery(agentId, taskId, branch);
 
-    // Release worktree after push (idempotent — hook may have released it already)
-    releaseWorktree(this.rawDb, this.projectDir, taskId);
-
     if (!delivery) {
-      process.stderr.write(`[dispatch-loop] no delivery record for ${taskId}, skipping monitor\n`);
+      process.stderr.write(
+        `[dispatch-loop] delivery failed for ${taskId} — preserving worktree and branch for manual recovery\n`
+      );
       return;
     }
+
+    // Release worktree only after successful push
+    releaseWorktree(this.rawDb, this.projectDir, taskId);
 
     const outcome = await monitorDelivery(this.rawDb, delivery, this.projectDir);
     process.stderr.write(`[dispatch-loop] ${taskId} delivery outcome: ${outcome}\n`);

--- a/src/server/dispatch.ts
+++ b/src/server/dispatch.ts
@@ -23,6 +23,7 @@ import { allocateWorktree } from '../modules/agents/worktree.js';
 import type { AllocateWorktreeResult } from '../modules/agents/worktree.js';
 import {
   createAgent,
+  getAgent,
   updateAgentStatus,
   setAgentContext,
   listAgents,
@@ -497,14 +498,17 @@ async function handleProcessExit(
 
   if (code === 0 && result) {
     const completion = parseCompletionMessage(result.result ?? '');
-    if (completion) {
+    // Skip handleCompletion (which sets task to 'done') when the agent has a
+    // branch — delivery hasn't happened yet. The dispatch loop will set the
+    // final task status after push + PR via ensureDelivery.
+    const agent = getAgent(svc.db, agentId);
+    const hasBranch = !!agent?.branch?.startsWith('agent/');
+    if (completion && !hasBranch) {
       await handleCompletion(svc.db, svc.config, svc.embedder, completion);
-      updateAgentStatus(svc.db, agentId, 'completed', { summary: completion.summary });
-    } else {
-      updateAgentStatus(svc.db, agentId, 'completed', {
-        summary: 'Completed without protocol message',
-      });
     }
+    updateAgentStatus(svc.db, agentId, 'completed', {
+      summary: completion?.summary ?? 'Completed without protocol message',
+    });
   } else if (code === 143) {
     updateAgentStatus(svc.db, agentId, 'failed', { exit_reason: 'rate_limited' });
   } else {


### PR DESCRIPTION
## Summary

- **Delivery pipeline**: Fix three bugs causing agent output loss in workstream dispatch
- **Dashboard serving**: Fix path resolution for global binary, add CWD fallback
- **Multi-session MCP**: Graceful port handling when multiple Claude sessions spawn MCP servers

## Delivery pipeline fixes

1. **Stale delivery record check** — `ensureDelivery` returned `push-failed` records as successful, skipping retry and proceeding to worktree cleanup. Now checks delivery status and retries for failed/in-progress records.
2. **Task status race** — `handleProcessExit` called `handleCompletion` (setting task to `done`) even for agents with branches awaiting delivery. This overwrote the agent-done hook's `pending-merge` status and triggered premature dependency cascade. Now skips `handleCompletion` for branched agents.
3. **Push timeout** — `pushBranch` had a 10s timeout that could fail on large diffs. Increased to 60s.
4. **Worktree preservation** — Failed deliveries no longer destroy the worktree and branch. Preserved for manual recovery.

## Dashboard fixes

- Path resolution falls back to `process.cwd()/dist/dashboard` when the relative path (from global binary) doesn't contain the build
- MCP config changed from `--mcp` (stdio only) to `--port 7800` to serve dashboard from same process
- `EADDRINUSE` handled gracefully — second sessions fall back to stdio-only

## Test plan

- [x] Typecheck passes
- [x] Lint passes  
- [x] 352 tests pass across 19 affected test files
- [x] New test: retry delivery when existing record has push-failed status
- [ ] Smoke test: single-task dispatch with full delivery pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)