### PR TITLE
VNM-45.16: Progress reporting and run history for autoloop

### DIFF
--- a/__tests__/modules/autoloop/format-utils.test.ts
+++ b/__tests__/modules/autoloop/format-utils.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { formatDuration } from '../../../src/modules/autoloop/engine/format-utils.js';
+
+describe('formatDuration', () => {
+  it('formats sub-minute durations as seconds', () => {
+    expect(formatDuration(5000)).toBe('5s');
+    expect(formatDuration(45_000)).toBe('45s');
+  });
+
+  it('formats exact minutes without remainder', () => {
+    expect(formatDuration(60_000)).toBe('1m');
+    expect(formatDuration(300_000)).toBe('5m');
+  });
+
+  it('formats minutes with seconds remainder', () => {
+    expect(formatDuration(90_000)).toBe('1m 30s');
+    expect(formatDuration(125_000)).toBe('2m 5s');
+  });
+
+  it('rounds milliseconds to nearest second', () => {
+    expect(formatDuration(1499)).toBe('1s');
+    expect(formatDuration(1500)).toBe('2s');
+  });
+
+  it('formats zero duration', () => {
+    expect(formatDuration(0)).toBe('0s');
+  });
+});

--- a/__tests__/modules/autoloop/history-formatter.test.ts
+++ b/__tests__/modules/autoloop/history-formatter.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { RunRecord } from '../../../src/modules/autoloop/engine/run-tracker.js';
+import { formatRunHistory } from '../../../src/modules/autoloop/engine/history-formatter.js';
+import type { BrainDB } from '../../../src/services/brain-db.js';
+
+function makeRun(overrides: Partial<RunRecord> = {}): RunRecord {
+  return {
+    id: 1,
+    loopType: 'session-review',
+    status: 'completed',
+    startedAt: '2026-04-11T10:00:00.000Z',
+    completedAt: '2026-04-11T10:05:00.000Z',
+    durationMs: 300_000,
+    reportNoteId: null,
+    ...overrides,
+  };
+}
+
+describe('history-formatter', () => {
+  const mockDb = {
+    getNoteById: vi.fn().mockReturnValue(null),
+  } as unknown as BrainDB;
+
+  describe('formatRunHistory', () => {
+    it('shows empty message when no runs exist', () => {
+      const output = formatRunHistory([], { detail: false, db: mockDb });
+      expect(output).toContain('No autoloop runs recorded yet');
+    });
+
+    it('formats summary view with one-liner per run', () => {
+      const runs = [
+        makeRun({ loopType: 'session-review', status: 'completed', durationMs: 300_000 }),
+        makeRun({
+          id: 2,
+          loopType: 'task-consolidation',
+          status: 'partial',
+          startedAt: '2026-04-10T08:00:00.000Z',
+          durationMs: 120_000,
+        }),
+      ];
+
+      const output = formatRunHistory(runs, { detail: false, db: mockDb });
+      expect(output).toContain('Autoloop Run History');
+      expect(output).toContain('review');
+      expect(output).toContain('completed');
+      expect(output).toContain('5m');
+      expect(output).toContain('consolidate');
+      expect(output).toContain('partial');
+      expect(output).toContain('2m');
+      expect(output).toContain('2 run(s) shown');
+      expect(output).toContain('--detail');
+    });
+
+    it('formats date as YYYY-MM-DD HH:MM in summary', () => {
+      const runs = [makeRun({ startedAt: '2026-04-11T10:30:00.000Z' })];
+      const output = formatRunHistory(runs, { detail: false, db: mockDb });
+      expect(output).toContain('2026-04-11 10:30');
+    });
+
+    it('shows ? for missing duration in summary', () => {
+      const runs = [makeRun({ durationMs: null })];
+      const output = formatRunHistory(runs, { detail: false, db: mockDb });
+      expect(output).toContain('?');
+    });
+
+    it('formats detail view with run metadata', () => {
+      const runs = [
+        makeRun({
+          loopType: 'session-review',
+          status: 'completed',
+          startedAt: '2026-04-11T10:00:00.000Z',
+          completedAt: '2026-04-11T10:05:00.000Z',
+          durationMs: 300_000,
+        }),
+      ];
+
+      const output = formatRunHistory(runs, { detail: true, db: mockDb });
+      expect(output).toContain('Session Review');
+      expect(output).toContain('Started:');
+      expect(output).toContain('2026-04-11T10:00:00.000Z');
+      expect(output).toContain('Finished:');
+      expect(output).toContain('Status:   completed');
+      expect(output).toContain('Duration: 5m');
+    });
+
+    it('omits finished line when completedAt is null', () => {
+      const runs = [makeRun({ completedAt: null })];
+      const output = formatRunHistory(runs, { detail: true, db: mockDb });
+      expect(output).not.toContain('Finished:');
+    });
+
+    it('omits duration line when durationMs is null', () => {
+      const runs = [makeRun({ durationMs: null })];
+      const output = formatRunHistory(runs, { detail: true, db: mockDb });
+      expect(output).not.toContain('Duration:');
+    });
+  });
+});

--- a/__tests__/modules/autoloop/report-generator.test.ts
+++ b/__tests__/modules/autoloop/report-generator.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { AutoloopReport } from '../../../src/modules/autoloop/types.js';
+
+vi.mock('../../../src/services/indexing.js', () => ({
+  indexSingleFile: vi.fn().mockResolvedValue('mock-note-id'),
+}));
+
+import { generateReportNote } from '../../../src/modules/autoloop/engine/report-generator.js';
+import type { BrainDB } from '../../../src/services/brain-db.js';
+import type { BrainConfig } from '../../../src/types.js';
+import type { Embedder } from '../../../src/types.js';
+
+function makeReport(overrides: Partial<AutoloopReport> = {}): AutoloopReport {
+  return {
+    loopType: 'session-review',
+    status: 'completed',
+    startedAt: '2026-04-11T10:00:00.000Z',
+    completedAt: '2026-04-11T10:05:00.000Z',
+    durationMs: 300_000,
+    sessionsReviewed: 3,
+    insightsExtracted: 5,
+    tasksUpdated: 0,
+    notesCreated: 5,
+    errors: [],
+    ...overrides,
+  };
+}
+
+describe('report-generator', () => {
+  const testDir = join(tmpdir(), 'autoloop-report-gen-test');
+  const mockDb = {} as BrainDB;
+  const mockEmbedder = {} as Embedder;
+  const mockConfig = { notesDir: testDir } as BrainConfig;
+
+  beforeEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+    mkdirSync(testDir, { recursive: true });
+    vi.clearAllMocks();
+  });
+
+  describe('generateReportNote', () => {
+    it('creates a markdown report file', async () => {
+      const report = makeReport();
+      const result = await generateReportNote(mockDb, mockConfig, mockEmbedder, report);
+
+      expect(result.noteId).toBe('mock-note-id');
+      expect(result.filePath).toContain('report-session-review-2026-04-11');
+      expect(result.filePath).toMatch(/\.md$/);
+
+      const content = readFileSync(result.filePath, 'utf-8');
+      expect(content).toContain('type: autoloop-report');
+      expect(content).toContain('module: autoloop');
+      expect(content).toContain('loop_type: session-review');
+      expect(content).toContain('status: completed');
+    });
+
+    it('includes summary section with metrics', async () => {
+      const report = makeReport({
+        sessionsReviewed: 7,
+        insightsExtracted: 12,
+        tasksUpdated: 3,
+        notesCreated: 10,
+      });
+      const result = await generateReportNote(mockDb, mockConfig, mockEmbedder, report);
+      const content = readFileSync(result.filePath, 'utf-8');
+
+      expect(content).toContain('**Sessions reviewed:** 7');
+      expect(content).toContain('**Insights extracted:** 12');
+      expect(content).toContain('**Tasks updated:** 3');
+      expect(content).toContain('**Notes created:** 10');
+    });
+
+    it('includes termination reason when present', async () => {
+      const report = makeReport({ terminationReason: 'Time limit exceeded' });
+      const result = await generateReportNote(mockDb, mockConfig, mockEmbedder, report);
+      const content = readFileSync(result.filePath, 'utf-8');
+
+      expect(content).toContain('termination_reason: "Time limit exceeded"');
+      expect(content).toContain('**Terminated:** Time limit exceeded');
+    });
+
+    it('includes details sections when provided', async () => {
+      const report = makeReport({
+        details: {
+          sessionIds: ['s1', 's2'],
+          sessionDisplayIds: ['session-001', 'session-002'],
+          insightsByCategory: { pattern: 3, friction: 2 },
+          frictionPatterns: ['retry loops', 'missing imports'],
+          duplicatesFound: 1,
+          duplicatePairs: [{ taskA: 'VNM-1.01', taskB: 'VNM-1.02', similarity: 0.92 }],
+          enrichmentsSuggested: 2,
+          enrichedTaskIds: ['VNM-2.01', 'VNM-2.02'],
+        },
+      });
+      const result = await generateReportNote(mockDb, mockConfig, mockEmbedder, report);
+      const content = readFileSync(result.filePath, 'utf-8');
+
+      expect(content).toContain('## Sessions Reviewed');
+      expect(content).toContain('- session-001');
+      expect(content).toContain('- session-002');
+      expect(content).toContain('## Insights by Category');
+      expect(content).toContain('**pattern:** 3');
+      expect(content).toContain('**friction:** 2');
+      expect(content).toContain('## Friction Patterns');
+      expect(content).toContain('- retry loops');
+      expect(content).toContain('## Duplicates Found');
+      expect(content).toContain('VNM-1.01 ↔ VNM-1.02');
+      expect(content).toContain('## Enrichments');
+      expect(content).toContain('- VNM-2.01');
+    });
+
+    it('includes errors section when present', async () => {
+      const report = makeReport({ errors: ['Failed to parse session.jsonl', 'LLM timeout'] });
+      const result = await generateReportNote(mockDb, mockConfig, mockEmbedder, report);
+      const content = readFileSync(result.filePath, 'utf-8');
+
+      expect(content).toContain('## Errors');
+      expect(content).toContain('- Failed to parse session.jsonl');
+      expect(content).toContain('- LLM timeout');
+    });
+
+    it('handles task-consolidation loop type', async () => {
+      const report = makeReport({ loopType: 'task-consolidation' });
+      const result = await generateReportNote(mockDb, mockConfig, mockEmbedder, report);
+      const content = readFileSync(result.filePath, 'utf-8');
+
+      expect(result.filePath).toContain('report-task-consolidation');
+      expect(content).toContain('loop_type: task-consolidation');
+      expect(content).toContain('Task Consolidation');
+    });
+
+    it('sets visibility to private', async () => {
+      const result = await generateReportNote(mockDb, mockConfig, mockEmbedder, makeReport());
+      const content = readFileSync(result.filePath, 'utf-8');
+
+      expect(content).toContain('visibility: private');
+    });
+  });
+});

--- a/__tests__/modules/autoloop/run-tracker.test.ts
+++ b/__tests__/modules/autoloop/run-tracker.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import type { BrainDB } from '../../../src/services/brain-db.js';
+import type { AutoloopReport } from '../../../src/modules/autoloop/types.js';
+import {
+  recordAutoloopRun,
+  getLastRunTime,
+  isOnCooldown,
+  getRunHistory,
+} from '../../../src/modules/autoloop/engine/run-tracker.js';
+
+function createTestDb(): BrainDB {
+  const rawDb = new Database(':memory:');
+  rawDb.exec(`
+    CREATE TABLE IF NOT EXISTS autoloop_runs (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      loop_type   TEXT    NOT NULL,
+      status      TEXT    NOT NULL,
+      started_at  TEXT    NOT NULL,
+      completed_at TEXT,
+      duration_ms INTEGER,
+      report_note_id TEXT,
+      UNIQUE(loop_type, started_at)
+    );
+    CREATE INDEX IF NOT EXISTS idx_autoloop_runs_type
+      ON autoloop_runs(loop_type, started_at);
+  `);
+  return { rawDb } as unknown as BrainDB;
+}
+
+function makeReport(overrides: Partial<AutoloopReport> = {}): AutoloopReport {
+  return {
+    loopType: 'session-review',
+    status: 'completed',
+    startedAt: '2026-04-11T10:00:00.000Z',
+    completedAt: '2026-04-11T10:05:00.000Z',
+    durationMs: 300_000,
+    sessionsReviewed: 3,
+    insightsExtracted: 5,
+    tasksUpdated: 0,
+    notesCreated: 5,
+    errors: [],
+    ...overrides,
+  };
+}
+
+describe('run-tracker', () => {
+  let db: BrainDB;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  afterEach(() => {
+    (db as unknown as { rawDb: Database.Database }).rawDb.close();
+  });
+
+  describe('recordAutoloopRun', () => {
+    it('inserts a run record', () => {
+      const report = makeReport();
+      recordAutoloopRun(db, report, 'note-123');
+
+      const runs = getRunHistory(db);
+      expect(runs).toHaveLength(1);
+      expect(runs[0].loopType).toBe('session-review');
+      expect(runs[0].status).toBe('completed');
+      expect(runs[0].reportNoteId).toBe('note-123');
+    });
+
+    it('records without a report note id', () => {
+      recordAutoloopRun(db, makeReport());
+
+      const runs = getRunHistory(db);
+      expect(runs).toHaveLength(1);
+      expect(runs[0].reportNoteId).toBeNull();
+    });
+
+    it('replaces duplicate (same loop_type + started_at)', () => {
+      const report = makeReport();
+      recordAutoloopRun(db, report, 'note-1');
+      recordAutoloopRun(db, { ...report, status: 'failed' }, 'note-2');
+
+      const runs = getRunHistory(db);
+      expect(runs).toHaveLength(1);
+      expect(runs[0].status).toBe('failed');
+      expect(runs[0].reportNoteId).toBe('note-2');
+    });
+  });
+
+  describe('getLastRunTime', () => {
+    it('returns null when no runs exist', () => {
+      expect(getLastRunTime(db, 'session-review')).toBeNull();
+    });
+
+    it('returns the most recent completed_at', () => {
+      recordAutoloopRun(
+        db,
+        makeReport({ startedAt: '2026-04-10T08:00:00Z', completedAt: '2026-04-10T08:05:00Z' })
+      );
+      recordAutoloopRun(
+        db,
+        makeReport({ startedAt: '2026-04-11T10:00:00Z', completedAt: '2026-04-11T10:05:00Z' })
+      );
+
+      const last = getLastRunTime(db, 'session-review');
+      expect(last).toBeInstanceOf(Date);
+      expect(last!.toISOString()).toBe('2026-04-11T10:05:00.000Z');
+    });
+
+    it('filters by loop type', () => {
+      recordAutoloopRun(
+        db,
+        makeReport({ loopType: 'session-review', completedAt: '2026-04-11T10:00:00Z' })
+      );
+      recordAutoloopRun(
+        db,
+        makeReport({ loopType: 'task-consolidation', completedAt: '2026-04-11T12:00:00Z' })
+      );
+
+      const last = getLastRunTime(db, 'session-review');
+      expect(last!.toISOString()).toBe('2026-04-11T10:00:00.000Z');
+    });
+  });
+
+  describe('isOnCooldown', () => {
+    it('returns false when no runs exist', () => {
+      expect(isOnCooldown(db, 'session-review', 60_000)).toBe(false);
+    });
+
+    it('returns true when last run is within cooldown window', () => {
+      const now = new Date().toISOString();
+      recordAutoloopRun(db, makeReport({ completedAt: now }));
+
+      expect(isOnCooldown(db, 'session-review', 60_000)).toBe(true);
+    });
+
+    it('returns false when last run is older than cooldown window', () => {
+      const old = new Date(Date.now() - 120_000).toISOString();
+      recordAutoloopRun(db, makeReport({ completedAt: old }));
+
+      expect(isOnCooldown(db, 'session-review', 60_000)).toBe(false);
+    });
+  });
+
+  describe('getRunHistory', () => {
+    it('returns empty array when no runs exist', () => {
+      expect(getRunHistory(db)).toEqual([]);
+    });
+
+    it('returns runs ordered by started_at descending', () => {
+      recordAutoloopRun(db, makeReport({ startedAt: '2026-04-10T08:00:00Z' }));
+      recordAutoloopRun(db, makeReport({ startedAt: '2026-04-11T10:00:00Z' }));
+      recordAutoloopRun(db, makeReport({ startedAt: '2026-04-09T06:00:00Z' }));
+
+      const runs = getRunHistory(db);
+      expect(runs).toHaveLength(3);
+      expect(runs[0].startedAt).toBe('2026-04-11T10:00:00Z');
+      expect(runs[1].startedAt).toBe('2026-04-10T08:00:00Z');
+      expect(runs[2].startedAt).toBe('2026-04-09T06:00:00Z');
+    });
+
+    it('respects limit option', () => {
+      recordAutoloopRun(db, makeReport({ startedAt: '2026-04-10T08:00:00Z' }));
+      recordAutoloopRun(db, makeReport({ startedAt: '2026-04-11T10:00:00Z' }));
+      recordAutoloopRun(db, makeReport({ startedAt: '2026-04-09T06:00:00Z' }));
+
+      const runs = getRunHistory(db, { limit: 2 });
+      expect(runs).toHaveLength(2);
+    });
+
+    it('filters by loop type', () => {
+      recordAutoloopRun(
+        db,
+        makeReport({ loopType: 'session-review', startedAt: '2026-04-10T08:00:00Z' })
+      );
+      recordAutoloopRun(
+        db,
+        makeReport({ loopType: 'task-consolidation', startedAt: '2026-04-11T10:00:00Z' })
+      );
+
+      const runs = getRunHistory(db, { loopType: 'task-consolidation' });
+      expect(runs).toHaveLength(1);
+      expect(runs[0].loopType).toBe('task-consolidation');
+    });
+
+    it('maps row fields correctly', () => {
+      recordAutoloopRun(
+        db,
+        makeReport({
+          startedAt: '2026-04-11T10:00:00Z',
+          completedAt: '2026-04-11T10:05:00Z',
+          durationMs: 300_000,
+        }),
+        'note-abc'
+      );
+
+      const [run] = getRunHistory(db);
+      expect(run.loopType).toBe('session-review');
+      expect(run.status).toBe('completed');
+      expect(run.startedAt).toBe('2026-04-11T10:00:00Z');
+      expect(run.completedAt).toBe('2026-04-11T10:05:00Z');
+      expect(run.durationMs).toBe(300_000);
+      expect(run.reportNoteId).toBe('note-abc');
+      expect(typeof run.id).toBe('number');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds format utils, run tracker, report generator, and history formatter
- 33 unit tests covering all output modes and edge cases

## Test plan
- [x] `npx vitest run __tests__/modules/autoloop/{format-utils,history-formatter,report-generator,run-tracker}.test.ts` — 33 tests pass
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)