### PR TITLE
Add agent artifacts and screenshots to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,12 @@ coverage/
 .brain/
 .worktrees/
 .claude/skills/
+.claude/scheduled_tasks.lock
+
+# Agent/tool artifacts
+.ao/
+.playwright-mcp/
+.recovered/
+
+# Screenshots (development artifacts)
+*.png


### PR DESCRIPTION
## Summary
- Add `.ao/`, `.playwright-mcp/`, `.recovered/`, `*.png`, `.claude/scheduled_tasks.lock` to .gitignore
- Prevents untracked files from leaking into agent branches during rebase

Found during VNM-56 merge: rebase of .26 picked up 100 untracked files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)