### PR TITLE
VNM-56.30: Human review gate with inbox, CLI, and MCP signal

### DIFF
--- a/__tests__/modules/agents/agent-commands.test.ts
+++ b/__tests__/modules/agents/agent-commands.test.ts
@@ -1,6 +1,12 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
-import { agentsMigrationV1, agentsMigrationV2 } from '../../../src/modules/agents/schema.js';
+import {
+  agentsMigrationV1,
+  agentsMigrationV2,
+  agentsMigrationV3,
+  agentsMigrationV4,
+} from '../../../src/modules/agents/schema.js';
+import { recordDelivery } from '../../../src/modules/agents/delivery.js';
 
 // We use a raw better-sqlite3 Database that has the agents migration applied.
 // The data.ts toRaw() helper handles both BrainDB and raw Database instances.
@@ -40,6 +46,8 @@ beforeEach(() => {
   db = new Database(':memory:');
   agentsMigrationV1.up(db);
   agentsMigrationV2.up(db);
+  agentsMigrationV3.up(db);
+  agentsMigrationV4.up(db);
 
   stdoutData = '';
   stderrData = '';
@@ -455,5 +463,77 @@ describe('agent status', () => {
     await run('status', '--agent', 'no-such-id');
     expect(stderrData).toContain('not found');
     expect(process.exitCode).toBe(1);
+  });
+});
+
+describe('agent approve / reject', () => {
+  function seedPausedDelivery(agentName: string, taskId: string): string {
+    db.prepare(
+      `INSERT INTO agents (id, name, parent, status, created_at, context)
+       VALUES (?, ?, 'orchestrator', 'active', ?, '{}')`
+    ).run(agentName, agentName, new Date().toISOString());
+    recordDelivery(db, agentName, {
+      status: 'review-paused',
+      task_id: taskId,
+      branch: `agent/${taskId}`,
+    });
+    return agentName;
+  }
+
+  it('approve sets human_signal to approve', async () => {
+    seedPausedDelivery('agent-approve-1', 'VNM-56.30');
+    await run('approve', 'VNM-56.30');
+    const row = db
+      .prepare('SELECT human_signal FROM delivery_states WHERE agent_id = ?')
+      .get('agent-approve-1') as { human_signal: string };
+    expect(row.human_signal).toBe('approve');
+    expect(stdoutData).toContain('Signaled approve for VNM-56.30');
+  });
+
+  it('reject sets human_signal to needs_fixes', async () => {
+    seedPausedDelivery('agent-reject-1', 'VNM-56.31');
+    await run('reject', 'VNM-56.31');
+    const row = db
+      .prepare('SELECT human_signal FROM delivery_states WHERE agent_id = ?')
+      .get('agent-reject-1') as { human_signal: string };
+    expect(row.human_signal).toBe('needs_fixes');
+    expect(stdoutData).toContain('Signaled needs_fixes for VNM-56.31');
+  });
+
+  it('approve errors when no delivery exists for taskId', async () => {
+    await run('approve', 'VNM-99.99');
+    expect(stderrData).toContain('No delivery found');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('uppercases taskId before lookup', async () => {
+    seedPausedDelivery('agent-lower-1', 'VNM-56.30');
+    await run('approve', 'vnm-56.30');
+    const row = db
+      .prepare('SELECT human_signal FROM delivery_states WHERE agent_id = ?')
+      .get('agent-lower-1') as { human_signal: string };
+    expect(row.human_signal).toBe('approve');
+  });
+
+  it('errors when delivery is not in review-paused status', async () => {
+    db.prepare(
+      `INSERT INTO agents (id, name, parent, status, created_at, context)
+       VALUES (?, ?, 'orchestrator', 'active', ?, '{}')`
+    ).run('agent-open-1', 'agent-open-1', new Date().toISOString());
+    recordDelivery(db, 'agent-open-1', {
+      status: 'pr-open',
+      task_id: 'VNM-56.32',
+      branch: 'agent/VNM-56.32',
+    });
+
+    await run('approve', 'VNM-56.32');
+    expect(stderrData).toContain("is in status 'pr-open'");
+    expect(stderrData).toContain("not 'review-paused'");
+    expect(process.exitCode).toBe(1);
+
+    const row = db
+      .prepare('SELECT human_signal FROM delivery_states WHERE agent_id = ?')
+      .get('agent-open-1') as { human_signal: string | null };
+    expect(row.human_signal).toBeNull();
   });
 });

--- a/__tests__/modules/agents/delivery-review.test.ts
+++ b/__tests__/modules/agents/delivery-review.test.ts
@@ -1,14 +1,61 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
 import type { DeliveryRecord } from '../../../src/modules/agents/delivery.js';
 import {
   runDeliveryReview,
   parseRiskScore,
+  runHumanReviewGate,
   type ReviewDeps,
   type ReviewRunOutput,
 } from '../../../src/modules/agents/delivery-review.js';
+import {
+  agentsMigrationV1,
+  agentsMigrationV2,
+  agentsMigrationV3,
+  agentsMigrationV4,
+} from '../../../src/modules/agents/schema.js';
+import {
+  recordDelivery,
+  signalDelivery,
+  readAndClearHumanSignal,
+  getDeliveryForTask,
+} from '../../../src/modules/agents/delivery.js';
 
-function makeDelivery(overrides: Partial<DeliveryRecord> = {}): DeliveryRecord {
+// Avoid pulling in real spawn/template machinery; we stub every agent call.
+vi.mock('../../../src/modules/workflow/engine/templates.js', () => ({
+  renderTemplate: vi.fn(() => ({ ok: false, error: new Error('no template') })),
+}));
+
+vi.mock('../../../src/utils/db.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/utils/db.js')>(
+    '../../../src/utils/db.js'
+  );
+  return { ...actual, sleep: vi.fn(() => Promise.resolve()) };
+});
+
+// Stub out child_process.spawn so the review/fixup agent helpers never
+// actually launch the `claude` binary. Each stub child exits immediately
+// with an empty stdout payload.
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+  return {
+    ...actual,
+    spawn: vi.fn(() => {
+      const child = {
+        stdin: { write: vi.fn(), end: vi.fn() },
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() },
+        on: vi.fn((event: string, cb: (arg?: unknown) => void) => {
+          if (event === 'exit') queueMicrotask(() => cb(0));
+          return child;
+        }),
+      };
+      return child as unknown as ReturnType<typeof actual.spawn>;
+    }),
+  };
+});
+
+function makeDelivery(_overrides: Partial<DeliveryRecord> = {}): DeliveryRecord {
   return {
     agent_id: 'agent-1',
     task_id: 'VNM-56.29',
@@ -20,13 +67,18 @@ function makeDelivery(overrides: Partial<DeliveryRecord> = {}): DeliveryRecord {
     delivered_at: null,
     retry_count: 0,
     session_id: null,
+    review_tier: null,
+    review_score: null,
+    fix_attempts: 0,
+    review_agent_id: null,
+    stall_reason: null,
+    human_signal: null,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
-    ...overrides,
   };
 }
 
-function makeDb(): Database.Database {
+function makeSimpleDb(): Database.Database {
   const db = new Database(':memory:');
   db.exec(`
     CREATE TABLE delivery_states (
@@ -43,11 +95,25 @@ function makeDb(): Database.Database {
       review_tier  TEXT,
       review_score INTEGER,
       review_agent_id TEXT,
+      stall_reason TEXT,
+      human_signal TEXT,
+      fix_attempts INTEGER DEFAULT 0,
       created_at   TEXT NOT NULL DEFAULT (datetime('now')),
       updated_at   TEXT NOT NULL DEFAULT (datetime('now'))
     );
     INSERT INTO delivery_states (agent_id, task_id, branch, status)
       VALUES ('agent-1', 'VNM-56.29', 'agent/VNM-56/VNM-56.29', 'pr-open');
+    CREATE TABLE inbox (
+      id TEXT PRIMARY KEY,
+      content TEXT NOT NULL,
+      title TEXT,
+      source TEXT NOT NULL,
+      source_url TEXT,
+      source_meta TEXT,
+      status TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      processed_at TEXT
+    );
   `);
   return db;
 }
@@ -75,6 +141,14 @@ function review(
   };
 }
 
+// Seed an approve signal so the human gate returns immediately for escalation tests.
+function seedApproveSignal(db: Database.Database, agentId: string): void {
+  db.prepare('UPDATE delivery_states SET human_signal = ? WHERE agent_id = ?').run(
+    'approve',
+    agentId
+  );
+}
+
 describe('parseRiskScore', () => {
   it('extracts risk score from agent output', () => {
     expect(parseRiskScore('### Risk: 3')).toBe(3);
@@ -95,7 +169,7 @@ describe('parseRiskScore', () => {
 
 describe('runDeliveryReview', () => {
   it('ci-only returns approved immediately without dispatching agents', async () => {
-    const db = makeDb();
+    const db = makeSimpleDb();
     const deps = makeDeps();
 
     const result = await runDeliveryReview(db, makeDelivery(), 'ci-only', '/tmp/project', deps);
@@ -113,7 +187,7 @@ describe('runDeliveryReview', () => {
   });
 
   it('ci-only persists review_tier', async () => {
-    const db = makeDb();
+    const db = makeSimpleDb();
     await runDeliveryReview(db, makeDelivery(), 'ci-only', '/tmp/project', makeDeps());
 
     const row = db
@@ -124,7 +198,7 @@ describe('runDeliveryReview', () => {
   });
 
   it('ai-review approves on PASS verdict with low risk', async () => {
-    const db = makeDb();
+    const db = makeSimpleDb();
     const deps = makeDeps({
       runReview: vi.fn(async () => review('Verdict: PASS\nRisk: 2', { agentId: 'r1' })),
     });
@@ -138,36 +212,39 @@ describe('runDeliveryReview', () => {
     db.close();
   });
 
-  it('escalates when risk >= 4 even if verdict says PASS (signal priority fix)', async () => {
-    const db = makeDb();
+  it('escalates to human gate when risk >= 4 even if verdict says PASS', async () => {
+    const db = makeSimpleDb();
+    seedApproveSignal(db, 'agent-1');
     const deps = makeDeps({
       runReview: vi.fn(async () => review('Verdict: PASS\nRisk Score: 5', { agentId: 'r1' })),
     });
 
     const result = await runDeliveryReview(db, makeDelivery(), 'ai-review', '/tmp/project', deps);
 
-    expect(result.approved).toBe(false);
-    expect(result.escalated).toBe(true);
     expect(result.riskScore).toBe(5);
+    expect(result.escalated).toBe(true);
+    // Approved because we seeded the approve signal
+    expect(result.approved).toBe(true);
     db.close();
   });
 
-  it('escalates when subprocess fails (empty output must not auto-approve)', async () => {
-    const db = makeDb();
+  it('escalates to human gate when subprocess fails', async () => {
+    const db = makeSimpleDb();
+    seedApproveSignal(db, 'agent-1');
     const deps = makeDeps({
       runReview: vi.fn(async () => review('', { success: false, agentId: 'failed-r1' })),
     });
 
     const result = await runDeliveryReview(db, makeDelivery(), 'ai-review', '/tmp/project', deps);
 
-    expect(result.approved).toBe(false);
     expect(result.escalated).toBe(true);
     expect(result.reviewAgentId).toBe('failed-r1');
     db.close();
   });
 
-  it('human-review tier always escalates', async () => {
-    const db = makeDb();
+  it('human-review tier always routes to human gate', async () => {
+    const db = makeSimpleDb();
+    seedApproveSignal(db, 'agent-1');
     const deps = makeDeps({
       runReview: vi.fn(async () => review('Verdict: PASS\nRisk: 1', { agentId: 'r1' })),
     });
@@ -180,13 +257,12 @@ describe('runDeliveryReview', () => {
       deps
     );
 
-    expect(result.approved).toBe(false);
     expect(result.escalated).toBe(true);
     db.close();
   });
 
   it('needs_fixes runs fixup loop and approves when re-review passes', async () => {
-    const db = makeDb();
+    const db = makeSimpleDb();
     const runReview = vi
       .fn()
       .mockResolvedValueOnce(review('Verdict: NEEDS WORK\nRisk: 2', { agentId: 'r1' }))
@@ -204,15 +280,15 @@ describe('runDeliveryReview', () => {
     db.close();
   });
 
-  it('fixup loop escalates after exhausting MAX_FIXUP_ITERATIONS', async () => {
-    const db = makeDb();
+  it('fixup loop escalates to human gate after exhausting MAX_FIXUP_ITERATIONS', async () => {
+    const db = makeSimpleDb();
+    seedApproveSignal(db, 'agent-1');
     const runReview = vi.fn(async () => review('Verdict: NEEDS WORK\nRisk: 2', { agentId: 'r' }));
     const runFixup = vi.fn(async () => review('', { agentId: 'f' }));
     const deps: ReviewDeps = { runReview, runFixup };
 
     const result = await runDeliveryReview(db, makeDelivery(), 'ai-review', '/tmp/project', deps);
 
-    expect(result.approved).toBe(false);
     expect(result.escalated).toBe(true);
     expect(result.fixupIterations).toBe(3);
     expect(runFixup).toHaveBeenCalledTimes(3);
@@ -221,7 +297,7 @@ describe('runDeliveryReview', () => {
   });
 
   it('persists review_score from every review iteration', async () => {
-    const db = makeDb();
+    const db = makeSimpleDb();
     const runReview = vi
       .fn()
       .mockResolvedValueOnce(review('Verdict: NEEDS WORK\nRisk: 2', { agentId: 'r1' }))
@@ -239,7 +315,7 @@ describe('runDeliveryReview', () => {
   });
 
   it('persists review_tier, review_score, and review_agent_id on approval', async () => {
-    const db = makeDb();
+    const db = makeSimpleDb();
     const deps = makeDeps({
       runReview: vi.fn(async () => review('Verdict: PASS\nRisk: 2', { agentId: 'reviewer-42' })),
     });
@@ -283,5 +359,269 @@ describe('runDeliveryReview', () => {
 
     expect(result.approved).toBe(true);
     db.close();
+  });
+});
+
+// ── signalDelivery / readAndClearHumanSignal ─────────────────────────────────
+
+describe('signalDelivery / readAndClearHumanSignal', () => {
+  let db: Database.Database;
+
+  function makeDeliveryWithMigrations(overrides: Partial<DeliveryRecord> = {}): DeliveryRecord {
+    const agentId = overrides.agent_id ?? 'agent-human-1';
+    const taskId = overrides.task_id ?? 'VNM-56.30';
+    const branch = overrides.branch ?? 'agent/VNM-56/VNM-56.30';
+    const status = (overrides.status ?? 'pr-open') as DeliveryRecord['status'];
+    db.prepare(
+      `INSERT INTO agents (id, name, parent, status, created_at, context)
+       VALUES (?, ?, 'orchestrator', 'active', ?, '{}')`
+    ).run(agentId, `agent-for-${taskId}`, new Date().toISOString());
+    recordDelivery(db, agentId, {
+      status,
+      task_id: taskId,
+      branch,
+      pr_number: 101,
+      pr_url: `https://github.com/example/repo/pull/101`,
+    });
+    return getDeliveryForTask(db, taskId)!;
+  }
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    agentsMigrationV1.up(db);
+    agentsMigrationV2.up(db);
+    agentsMigrationV3.up(db);
+    agentsMigrationV4.up(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('writes approve signal and returns ok result when delivery is review-paused', () => {
+    const delivery = makeDeliveryWithMigrations({ status: 'review-paused' });
+    const result = signalDelivery(db, 'VNM-56.30', 'approve');
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.delivery.agent_id).toBe(delivery.agent_id);
+    expect(result.delivery.human_signal).toBe('approve');
+
+    const reloaded = getDeliveryForTask(db, 'VNM-56.30');
+    expect(reloaded!.human_signal).toBe('approve');
+  });
+
+  it('writes needs_fixes signal when delivery is review-paused', () => {
+    makeDeliveryWithMigrations({ status: 'review-paused' });
+    const result = signalDelivery(db, 'VNM-56.30', 'needs_fixes');
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.delivery.human_signal).toBe('needs_fixes');
+  });
+
+  it('returns not-found when no delivery exists for taskId', () => {
+    const result = signalDelivery(db, 'NOPE-99.99', 'approve');
+    expect(result).toEqual({ ok: false, reason: 'not-found' });
+  });
+
+  it('returns not-paused and does not write when delivery is not review-paused', () => {
+    const delivery = makeDeliveryWithMigrations(); // defaults to pr-open
+    const result = signalDelivery(db, 'VNM-56.30', 'approve');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.reason).toBe('not-paused');
+    if (result.reason !== 'not-paused') throw new Error('expected not-paused');
+    expect(result.delivery.agent_id).toBe(delivery.agent_id);
+    expect(result.delivery.status).toBe('pr-open');
+
+    const reloaded = getDeliveryForTask(db, 'VNM-56.30');
+    expect(reloaded!.human_signal).toBeNull();
+  });
+
+  it('rejects invalid signals', () => {
+    makeDeliveryWithMigrations({ status: 'review-paused' });
+    expect(() => signalDelivery(db, 'VNM-56.30', 'maybe' as unknown as 'approve')).toThrow(
+      /Invalid human signal/
+    );
+  });
+
+  it('readAndClearHumanSignal returns null when no signal is set', () => {
+    const delivery = makeDeliveryWithMigrations({ status: 'review-paused' });
+    expect(readAndClearHumanSignal(db, delivery.agent_id)).toBeNull();
+  });
+
+  it('readAndClearHumanSignal returns the signal and clears it', () => {
+    const delivery = makeDeliveryWithMigrations({ status: 'review-paused' });
+    signalDelivery(db, 'VNM-56.30', 'approve');
+
+    const first = readAndClearHumanSignal(db, delivery.agent_id);
+    expect(first).toBe('approve');
+
+    const second = readAndClearHumanSignal(db, delivery.agent_id);
+    expect(second).toBeNull();
+  });
+});
+
+// ── runHumanReviewGate ──────────────────────────────────────────────────────
+
+describe('runHumanReviewGate', () => {
+  let db: Database.Database;
+
+  function makeDeliveryWithMigrations(overrides: Partial<DeliveryRecord> = {}): DeliveryRecord {
+    const agentId = overrides.agent_id ?? 'agent-human-1';
+    const taskId = overrides.task_id ?? 'VNM-56.30';
+    const branch = overrides.branch ?? 'agent/VNM-56/VNM-56.30';
+    const status = (overrides.status ?? 'pr-open') as DeliveryRecord['status'];
+    db.prepare(
+      `INSERT INTO agents (id, name, parent, status, created_at, context)
+       VALUES (?, ?, 'orchestrator', 'active', ?, '{}')`
+    ).run(agentId, `agent-for-${taskId}`, new Date().toISOString());
+    recordDelivery(db, agentId, {
+      status,
+      task_id: taskId,
+      branch,
+      pr_number: 101,
+      pr_url: `https://github.com/example/repo/pull/101`,
+    });
+    return getDeliveryForTask(db, taskId)!;
+  }
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    agentsMigrationV1.up(db);
+    agentsMigrationV2.up(db);
+    agentsMigrationV3.up(db);
+    agentsMigrationV4.up(db);
+    db.exec(`
+      CREATE TABLE inbox (
+        id TEXT PRIMARY KEY,
+        content TEXT NOT NULL,
+        title TEXT,
+        source TEXT NOT NULL,
+        source_url TEXT,
+        source_meta TEXT,
+        status TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        processed_at TEXT
+      )
+    `);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('approves on first human signal, returns approved result and resumes to pr-open', async () => {
+    const delivery = makeDeliveryWithMigrations({ status: 'review-paused' });
+
+    // Pre-seed the approve signal so the poll returns immediately.
+    signalDelivery(db, delivery.task_id!, 'approve');
+
+    const result = await runHumanReviewGate(
+      db,
+      delivery,
+      'reviewer-agent-1',
+      3,
+      'Verdict: NEEDS WORK\nRisk: 3\n\n## Key Findings\nAuth flow is risky.\n\n## Files of Interest\nsrc/auth/token.ts\n',
+      '/tmp/project',
+      0
+    );
+
+    expect(result.approved).toBe(true);
+    expect(result.escalated).toBe(true);
+    expect(result.reviewAgentId).toBe('reviewer-agent-1');
+
+    // Delivery should be back to pr-open for the monitor to handle.
+    const final = getDeliveryForTask(db, delivery.task_id!);
+    expect(final!.status).toBe('pr-open');
+    expect(final!.review_agent_id).toBe('reviewer-agent-1');
+
+    // Inbox item should have been created.
+    const inbox = db.prepare('SELECT * FROM inbox').all() as Array<{
+      content: string;
+      source: string;
+      source_meta: string;
+      status: string;
+    }>;
+    expect(inbox).toHaveLength(1);
+    expect(inbox[0].source).toBe('api');
+    expect(inbox[0].content).toMatch(/Review Required/);
+    expect(inbox[0].content).toMatch(/Risk Score.*3/);
+    expect(inbox[0].content).toMatch(/brain agent approve VNM-56.30/);
+    const meta = JSON.parse(inbox[0].source_meta) as Record<string, unknown>;
+    expect(meta.action).toBe('review-requested');
+    expect(meta.taskId).toBe('VNM-56.30');
+  });
+
+  it('transitions to stalled with review-rejected after two rejections', async () => {
+    const delivery = makeDeliveryWithMigrations();
+
+    // Drive the poll: on each sleep tick, write a needs_fixes signal directly
+    // via SQL (bypasses the status guard so the test doesn't depend on the
+    // internal transition order).
+    const originalSleep = await import('../../../src/utils/db.js');
+    vi.mocked(originalSleep.sleep).mockImplementation(async () => {
+      db.prepare('UPDATE delivery_states SET human_signal = ? WHERE agent_id = ?').run(
+        'needs_fixes',
+        delivery.agent_id
+      );
+    });
+
+    const result = await runHumanReviewGate(
+      db,
+      delivery,
+      'reviewer-agent-1',
+      4,
+      '## Key Findings\nNeeds work.',
+      '/tmp/project',
+      0
+    );
+
+    expect(result.approved).toBe(false);
+    expect(result.escalated).toBe(true);
+    // After two rejections the gate stalls the delivery so crash recovery
+    // doesn't re-process it.
+    const final = getDeliveryForTask(db, delivery.task_id!);
+    expect(final!.status).toBe('stalled');
+    expect(final!.stall_reason).toBe('review-rejected');
+
+    // Two inbox notifications — one per cycle.
+    const rows = db.prepare(`SELECT source_meta FROM inbox ORDER BY created_at`).all() as Array<{
+      source_meta: string;
+    }>;
+    expect(rows).toHaveLength(2);
+    const actions = rows.map((r) => (JSON.parse(r.source_meta) as { action: string }).action);
+    expect(actions).toEqual(['review-requested', 'review-re-requested']);
+  });
+
+  it('transitions to stalled with review-timeout when no signal arrives before deadline', async () => {
+    const delivery = makeDeliveryWithMigrations();
+
+    // Freeze Date.now via a spy so we can deterministically march past the
+    // 7-day deadline. Each sleep() tick advances the clock by 8 days, which
+    // exceeds the gate's timeout on the first poll.
+    let fakeNow = new Date('2026-04-22T00:00:00Z').getTime();
+    vi.spyOn(Date, 'now').mockImplementation(() => fakeNow);
+
+    const originalSleep = await import('../../../src/utils/db.js');
+    vi.mocked(originalSleep.sleep).mockImplementation(async () => {
+      fakeNow += 8 * 24 * 60 * 60 * 1000;
+    });
+
+    const result = await runHumanReviewGate(
+      db,
+      delivery,
+      'reviewer-agent-1',
+      2,
+      '## Key Findings\nMinor.',
+      '/tmp/project',
+      0
+    );
+
+    expect(result.approved).toBe(false);
+    expect(result.escalated).toBe(true);
+
+    const final = getDeliveryForTask(db, delivery.task_id!);
+    expect(final!.status).toBe('stalled');
+    expect(final!.stall_reason).toBe('review-timeout');
   });
 });

--- a/src/modules/agents/commands.ts
+++ b/src/modules/agents/commands.ts
@@ -7,6 +7,7 @@ import { createWorktreeCommand } from './worktree-commands.js';
 import { buildAgentDispatchContext, formatDispatchBrief } from './dispatch-context.js';
 import { updateTaskStatus } from '../pm/data/task-ops.js';
 import { migrateAoAgents } from './migrate-ao.js';
+import { signalDelivery, type HumanSignal } from './delivery.js';
 import type { AgentArtifacts } from './agent-done-handler.js';
 import {
   getAgentCostEntries,
@@ -400,9 +401,48 @@ export function createAgentCommands(): Command {
       });
     });
 
+  // brain agent approve <taskId>
+  cmd
+    .command('approve')
+    .description('Approve a delivery paused for human review')
+    .argument('<task-id>', 'PM task display_id (e.g. VNM-56.30)')
+    .action(async (taskId) => {
+      await runDeliverySignal(taskId, 'approve');
+    });
+
+  // brain agent reject <taskId>
+  cmd
+    .command('reject')
+    .description('Reject a delivery paused for human review (triggers fixup cycle)')
+    .argument('<task-id>', 'PM task display_id (e.g. VNM-56.30)')
+    .action(async (taskId) => {
+      await runDeliverySignal(taskId, 'needs_fixes');
+    });
+
   cmd.addCommand(createWorktreeCommand());
 
   return cmd;
+}
+
+async function runDeliverySignal(taskId: string, signal: HumanSignal): Promise<void> {
+  await withDb((svc) => {
+    const rawDb = getRawDb(svc.db);
+    const result = signalDelivery(rawDb, taskId.toUpperCase(), signal);
+    if (!result.ok) {
+      if (result.reason === 'not-found') {
+        process.stderr.write(`Error: No delivery found for task: ${taskId}\n`);
+      } else {
+        process.stderr.write(
+          `Error: Delivery for ${taskId} is in status '${result.delivery.status}', not 'review-paused'. Signal would not be read.\n`
+        );
+      }
+      process.exitCode = 1;
+      return;
+    }
+    process.stdout.write(
+      `Signaled ${signal} for ${taskId} (agent ${result.delivery.agent_id}, status ${result.delivery.status}).\n`
+    );
+  });
 }
 
 function fmtTokens(n: number): string {

--- a/src/modules/agents/delivery-review.ts
+++ b/src/modules/agents/delivery-review.ts
@@ -5,8 +5,10 @@ import { randomUUID } from 'node:crypto';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { DeliveryRecord } from './delivery.js';
+import { recordDelivery, readAndClearHumanSignal } from './delivery.js';
 import { parseSignals } from '../workflow/runtime/signals.js';
 import { renderTemplate } from '../workflow/engine/templates.js';
+import { sleep } from '../../utils/db.js';
 
 export type ReviewTier = 'ci-only' | 'ai-review' | 'human-review';
 
@@ -38,16 +40,20 @@ const REVIEW_MODEL = 'claude-sonnet-4-6';
 const RESEARCH_TOOLS = 'Bash,Read,Glob,Grep,WebSearch,WebFetch';
 const FIXUP_TOOLS = 'Bash,Edit,Read,Write,Glob,Grep';
 const REVIEW_BUDGET_USD = '5.0';
+const HUMAN_SIGNAL_POLL_MS = 30_000;
+const HUMAN_REVIEW_MAX_CYCLES = 2;
+export const REVIEW_TIMEOUT_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
  * Run the review phase of delivery.
  *
  * - ci-only: no-op, returns immediately approved.
  * - ai-review: dispatches review-agent, parses signals, runs fixup loop up to
- *   MAX_FIXUP_ITERATIONS. De-escalates to merge when risk <= 2 and approved.
- *   Escalates to human-review tier on high_risk or exhausted fixups.
- * - human-review: dispatches review-agent but returns unapproved+escalated so
- *   the caller can route to the human gate (implemented in VNM-56.30).
+ *   MAX_FIXUP_ITERATIONS. Escalates to the human review gate on high_risk or
+ *   exhausted fixups.
+ * - human-review: dispatches review-agent and routes directly to the human
+ *   review gate, which pauses delivery until the user signals via
+ *   brain_delivery_signal or `brain agent approve/reject`.
  */
 export async function runDeliveryReview(
   db: Database.Database,
@@ -68,10 +74,10 @@ export async function runDeliveryReview(
   persistReviewScore(db, delivery.agent_id, riskScore);
 
   // A failed subprocess (timeout, budget cap, non-zero exit) leaves empty
-  // output that would otherwise parse to signal === null → approved. Treat
+  // output that would otherwise parse to signal === null -> approved. Treat
   // it as an escalation instead so the human gate can verify.
   if (!first.success) {
-    return escalate(riskScore, first.agentId, 0);
+    return runHumanReviewGate(db, delivery, first.agentId, riskScore, first.output, projectDir, 0);
   }
 
   // parseSignals returns the first-matching pattern, and `approved` is
@@ -79,13 +85,13 @@ export async function runDeliveryReview(
   // with a risk score of 5 would short-circuit to approved. Guard on the
   // risk score directly before dispatching on the signal.
   if (tier === 'human-review' || riskScore >= 4) {
-    return escalate(riskScore, first.agentId, 0);
+    return runHumanReviewGate(db, delivery, first.agentId, riskScore, first.output, projectDir, 0);
   }
 
   const signal = parseSignals('review', 'delivery', first.output);
 
   if (signal === 'high_risk') {
-    return escalate(riskScore, first.agentId, 0);
+    return runHumanReviewGate(db, delivery, first.agentId, riskScore, first.output, projectDir, 0);
   }
 
   if (signal !== 'needs_fixes') {
@@ -118,17 +124,41 @@ async function runFixupLoop(
     persistReviewScore(db, delivery.agent_id, latestRisk);
 
     if (!reReview.success) {
-      return escalate(latestRisk, latestReviewAgentId, fixupIterations);
+      return runHumanReviewGate(
+        db,
+        delivery,
+        latestReviewAgentId,
+        latestRisk,
+        reReview.output,
+        projectDir,
+        fixupIterations
+      );
     }
 
     if (latestRisk >= 4) {
-      return escalate(latestRisk, latestReviewAgentId, fixupIterations);
+      return runHumanReviewGate(
+        db,
+        delivery,
+        latestReviewAgentId,
+        latestRisk,
+        reReview.output,
+        projectDir,
+        fixupIterations
+      );
     }
 
     const signal = parseSignals('review', 'delivery', reReview.output);
 
     if (signal === 'high_risk') {
-      return escalate(latestRisk, latestReviewAgentId, fixupIterations);
+      return runHumanReviewGate(
+        db,
+        delivery,
+        latestReviewAgentId,
+        latestRisk,
+        reReview.output,
+        projectDir,
+        fixupIterations
+      );
     }
     if (signal !== 'needs_fixes') {
       return {
@@ -141,7 +171,15 @@ async function runFixupLoop(
     }
   }
 
-  return escalate(latestRisk, latestReviewAgentId, fixupIterations);
+  return runHumanReviewGate(
+    db,
+    delivery,
+    latestReviewAgentId,
+    latestRisk,
+    '',
+    projectDir,
+    fixupIterations
+  );
 }
 
 function approved(riskScore: number, reviewAgentId: string): DeliveryReviewResult {
@@ -154,27 +192,198 @@ function approved(riskScore: number, reviewAgentId: string): DeliveryReviewResul
   };
 }
 
-function escalate(
-  riskScore: number,
+interface ReviewSummary {
+  findings: string;
+  highlightedFiles: string;
+  questions: string;
+}
+
+export async function runHumanReviewGate(
+  db: Database.Database,
+  delivery: DeliveryRecord,
   reviewAgentId: string,
-  fixupIterations: number
-): DeliveryReviewResult {
+  riskScore: number,
+  reviewOutput: string,
+  projectDir: string,
+  priorFixupIterations: number
+): Promise<DeliveryReviewResult> {
+  let latestSummary = extractReviewSummary(reviewOutput);
+  let latestReviewAgentId = reviewAgentId;
+  let latestRisk = riskScore;
+  let fixupIterations = priorFixupIterations;
+
+  for (let cycle = 1; cycle <= HUMAN_REVIEW_MAX_CYCLES; cycle++) {
+    notifyHumanReview(db, delivery, latestSummary, latestRisk, latestReviewAgentId, cycle);
+    recordDelivery(db, delivery.agent_id, {
+      status: 'review-paused',
+      review_agent_id: latestReviewAgentId,
+    });
+
+    const deadline = Date.now() + REVIEW_TIMEOUT_MS;
+    const signal = await waitForHumanSignal(db, delivery.agent_id, deadline);
+
+    if (signal === 'approve') {
+      recordDelivery(db, delivery.agent_id, { status: 'pr-open' });
+      return {
+        approved: true,
+        riskScore: latestRisk,
+        escalated: true,
+        fixupIterations,
+        reviewAgentId: latestReviewAgentId,
+      };
+    }
+
+    if (signal === 'timeout') {
+      recordDelivery(db, delivery.agent_id, {
+        status: 'stalled',
+        stall_reason: 'review-timeout',
+      });
+      return {
+        approved: false,
+        riskScore: latestRisk,
+        escalated: true,
+        fixupIterations,
+        reviewAgentId: latestReviewAgentId,
+      };
+    }
+
+    if (cycle === HUMAN_REVIEW_MAX_CYCLES) break;
+
+    await defaultDeps.runFixup(delivery, projectDir);
+    fixupIterations++;
+    const reReview = await defaultDeps.runReview(db, delivery, projectDir);
+    latestReviewAgentId = reReview.agentId;
+    latestRisk = parseRiskScore(reReview.output);
+    latestSummary = extractReviewSummary(reReview.output);
+  }
+
+  recordDelivery(db, delivery.agent_id, {
+    status: 'stalled',
+    stall_reason: 'review-rejected',
+  });
   return {
     approved: false,
-    riskScore,
+    riskScore: latestRisk,
     escalated: true,
     fixupIterations,
-    reviewAgentId,
+    reviewAgentId: latestReviewAgentId,
   };
 }
 
+async function waitForHumanSignal(
+  db: Database.Database,
+  agentId: string,
+  deadline: number
+): Promise<'approve' | 'needs_fixes' | 'timeout'> {
+  while (Date.now() < deadline) {
+    const signal = readAndClearHumanSignal(db, agentId);
+    if (signal) return signal;
+    await sleep(HUMAN_SIGNAL_POLL_MS);
+  }
+  // Final check so a signal arriving just past the deadline isn't dropped.
+  const signal = readAndClearHumanSignal(db, agentId);
+  return signal ?? 'timeout';
+}
+
+function notifyHumanReview(
+  db: Database.Database,
+  delivery: DeliveryRecord,
+  summary: ReviewSummary,
+  riskScore: number,
+  reviewAgentId: string,
+  cycle: number
+): void {
+  const action = cycle === 1 ? 'review-requested' : 'review-re-requested';
+  const content = formatHumanReviewRequest(delivery, summary, riskScore, reviewAgentId, cycle);
+  const meta = JSON.stringify({
+    taskId: delivery.task_id,
+    prUrl: delivery.pr_url,
+    prNumber: delivery.pr_number,
+    reviewAgentId,
+    riskScore,
+    action,
+    cycle,
+  });
+  try {
+    db.prepare(
+      `INSERT INTO inbox (id, content, title, source, source_url, source_meta, status, created_at, processed_at)
+       VALUES (?, ?, ?, 'api', NULL, ?, 'pending', ?, NULL)`
+    ).run(
+      randomUUID(),
+      content,
+      `Review required: ${delivery.task_id ?? 'unknown'}`,
+      meta,
+      new Date().toISOString()
+    );
+  } catch (err) {
+    process.stderr.write(
+      `[delivery-review] failed to add inbox notification: ${err instanceof Error ? err.message : String(err)}\n`
+    );
+  }
+}
+
+function formatHumanReviewRequest(
+  delivery: DeliveryRecord,
+  summary: ReviewSummary,
+  riskScore: number,
+  reviewAgentId: string,
+  cycle: number
+): string {
+  const header =
+    cycle === 1
+      ? `## Review Required: ${delivery.task_id ?? 'unknown'}`
+      : `## Review Required (after fixup): ${delivery.task_id ?? 'unknown'}`;
+  return [
+    header,
+    '',
+    `**PR**: ${delivery.pr_url ?? 'unknown'}`,
+    `**Risk Score**: ${riskScore}/5 (tier: human-review)`,
+    `**Review Agent**: ${reviewAgentId}`,
+    '',
+    '### Key Findings',
+    summary.findings || '(none extracted)',
+    '',
+    '### Files of Interest',
+    summary.highlightedFiles || '(none extracted)',
+    '',
+    '### Open Questions',
+    summary.questions || '(none extracted)',
+    '',
+    `**Actions**: Signal \`approve\` or \`needs_fixes\` via \`brain_delivery_signal\` MCP tool, or run:`,
+    `  brain agent approve ${delivery.task_id ?? '<taskId>'}`,
+    `  brain agent reject ${delivery.task_id ?? '<taskId>'}`,
+  ].join('\n');
+}
+
+function extractReviewSummary(output: string): ReviewSummary {
+  return {
+    findings: extractSection(output, ['Key Findings', 'Findings', 'Summary']),
+    highlightedFiles: extractSection(output, ['Files of Interest', 'Files', 'Highlighted Files']),
+    questions: extractSection(output, ['Open Questions', 'Questions']),
+  };
+}
+
+function extractSection(output: string, headings: string[]): string {
+  for (const heading of headings) {
+    const pattern = new RegExp(`##?\\s*${heading}\\s*\\n([\\s\\S]*?)(?=\\n##\\s|\\n\\*\\*|$)`, 'i');
+    const match = output.match(pattern);
+    if (match) {
+      const text = match[1].trim();
+      if (text) return text;
+    }
+  }
+  return '';
+}
+
 async function runReviewAgent(
-  _db: Database.Database,
+  db: Database.Database,
   delivery: DeliveryRecord,
   projectDir: string
 ): Promise<ReviewRunOutput> {
   const prompt = buildReviewPrompt(delivery, projectDir);
-  return spawnClaudeReview(prompt, projectDir, RESEARCH_TOOLS);
+  const result = await spawnClaudeReview(prompt, projectDir, RESEARCH_TOOLS);
+  persistReviewAgentId(db, delivery.agent_id, result.agentId);
+  return result;
 }
 
 async function runFixupAgent(

--- a/src/modules/agents/delivery.ts
+++ b/src/modules/agents/delivery.ts
@@ -17,7 +17,6 @@ export type DeliveryStatus =
   | 'stalled'
   | 'redispatched'
   | 'review-paused';
-<<<<<<< HEAD
 
 export const VALID_DELIVERY_STATUSES: ReadonlySet<DeliveryStatus> = new Set([
   'in-progress',
@@ -32,8 +31,8 @@ export const VALID_DELIVERY_STATUSES: ReadonlySet<DeliveryStatus> = new Set([
   'redispatched',
   'review-paused',
 ]);
-=======
->>>>>>> 35dd88c (Wire crash recovery on MCP startup for review-paused deliveries)
+
+export type HumanSignal = 'approve' | 'needs_fixes';
 
 export interface DeliveryRecord {
   agent_id: string;
@@ -267,4 +266,42 @@ export async function initiateDelivery(
   recordDelivery(db, agentId, { status: 'pr-open', pr_number: pr.number, pr_url: pr.url });
 
   return getDelivery(db, agentId)!;
+}
+
+export type SignalResult =
+  | { ok: true; delivery: DeliveryRecord }
+  | { ok: false; reason: 'not-found' }
+  | { ok: false; reason: 'not-paused'; delivery: DeliveryRecord };
+
+export function signalDelivery(
+  db: Database.Database,
+  taskId: string,
+  signal: HumanSignal
+): SignalResult {
+  if (signal !== 'approve' && signal !== 'needs_fixes') {
+    throw new Error(`Invalid human signal: ${signal}`);
+  }
+  const delivery = getDeliveryForTask(db, taskId);
+  if (!delivery) return { ok: false, reason: 'not-found' };
+  if (delivery.status !== 'review-paused') {
+    return { ok: false, reason: 'not-paused', delivery };
+  }
+  db.prepare('UPDATE delivery_states SET human_signal = ? WHERE agent_id = ?').run(
+    signal,
+    delivery.agent_id
+  );
+  return { ok: true, delivery: { ...delivery, human_signal: signal } };
+}
+
+export function readAndClearHumanSignal(
+  db: Database.Database,
+  agentId: string
+): HumanSignal | null {
+  const row = db
+    .prepare('SELECT human_signal FROM delivery_states WHERE agent_id = ?')
+    .get(agentId) as { human_signal: string | null } | undefined;
+  if (!row?.human_signal) return null;
+  const signal = row.human_signal as HumanSignal;
+  db.prepare('UPDATE delivery_states SET human_signal = NULL WHERE agent_id = ?').run(agentId);
+  return signal;
 }

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -17,6 +17,7 @@ import { readTaskBody } from '../modules/pm/engine/dispatch.js';
 import type { TaskStatus } from '../modules/pm/types.js';
 import type { AgentStatus } from '../modules/agents/types.js';
 import { getAgent, listAgents, getAgentContext } from '../modules/agents/data.js';
+import { signalDelivery } from '../modules/agents/delivery.js';
 import { dispatchTask, resolveProjectDir } from './dispatch.js';
 import { OrchestrationService } from './orchestration.js';
 import type { WorkflowRuntime } from '../modules/workflow/runtime/runtime.js';
@@ -760,6 +761,38 @@ function registerDispatchTools(server: McpServer, svc: BrainServiceClass): void 
         })),
         filesTouched: [...filesSet].slice(0, 20),
       });
+    }
+  );
+
+  server.tool(
+    'brain_delivery_signal',
+    'Signal a human review decision on a paused delivery. Use approve to resume merge, needs_fixes to trigger a fixup cycle.',
+    {
+      taskId: z.string().describe('PM task display_id (e.g. VNM-56.30)'),
+      action: z
+        .enum(['approve', 'needs_fixes'])
+        .describe('Approve to merge; needs_fixes to iterate'),
+    },
+    async ({ taskId, action }) => {
+      try {
+        const result = signalDelivery(svc.db.rawDb, taskId.toUpperCase(), action);
+        if (!result.ok) {
+          if (result.reason === 'not-found') {
+            return errorResult(`No delivery found for task: ${taskId}`);
+          }
+          return errorResult(
+            `Delivery for ${taskId} is in status '${result.delivery.status}', not 'review-paused'. Signal would not be read.`
+          );
+        }
+        return textResult({
+          taskId: result.delivery.task_id,
+          agentId: result.delivery.agent_id,
+          status: result.delivery.status,
+          humanSignal: action,
+        });
+      } catch (err) {
+        return errorResult(err instanceof Error ? err.message : String(err));
+      }
     }
   );
 }


### PR DESCRIPTION
## Summary

Merges VNM-56.30 (human review path) onto main, preserving all .29 safety guards.

- `runHumanReviewGate` with 7-day timeout, inbox notification, fixup cycle on rejection
- `waitForHumanSignal` polls `human_signal` column (30s interval, 7-day deadline)
- `signalDelivery` with status guard (rejects signals on non-`review-paused` deliveries)
- `brain agent approve/reject <taskId>` CLI commands
- `brain_delivery_signal` MCP tool
- Two rejections → `stalled/review-rejected` terminal status
- Timeout → `stalled/review-timeout`

Replaces PR #171 (had merge conflicts with .29).

## Test plan
- [x] 24 delivery-review tests (includes .29 safety + .30 human gate)
- [x] 34 agent-commands tests (includes approve/reject CLI)
- [x] typecheck + lint clean
- [x] 1053 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)