### PR TITLE
VNM-56.41: Idempotent dispatch — skip tasks with completed agents

### DIFF
--- a/__tests__/modules/agents/dispatch-loop.test.ts
+++ b/__tests__/modules/agents/dispatch-loop.test.ts
@@ -10,6 +10,7 @@ vi.mock('../../../src/utils/db.js', () => ({
 
 vi.mock('../../../src/modules/agents/data.js', () => ({
   getAgent: vi.fn(),
+  findAgentByTask: vi.fn(),
 }));
 
 vi.mock('../../../src/modules/agents/delivery.js', () => ({
@@ -34,13 +35,14 @@ import {
   type DispatchLoopPmDeps,
   type SpawnResult,
 } from '../../../src/modules/agents/dispatch-loop.js';
-import { getAgent } from '../../../src/modules/agents/data.js';
+import { findAgentByTask, getAgent } from '../../../src/modules/agents/data.js';
 import { getDeliveryForTask, initiateDelivery } from '../../../src/modules/agents/delivery.js';
 import { releaseWorktree } from '../../../src/modules/agents/worktree.js';
 import { monitorDelivery } from '../../../src/modules/agents/delivery-monitor.js';
 import { updateTaskStatus } from '../../../src/modules/pm/data/task-ops.js';
 
 const mockGetAgent = getAgent as ReturnType<typeof vi.fn>;
+const mockFindAgentByTask = findAgentByTask as ReturnType<typeof vi.fn>;
 const mockGetDelivery = getDeliveryForTask as ReturnType<typeof vi.fn>;
 const mockInitiateDelivery = initiateDelivery as ReturnType<typeof vi.fn>;
 const mockReleaseWorktree = releaseWorktree as ReturnType<typeof vi.fn>;
@@ -55,6 +57,8 @@ describe('DispatchLoop', () => {
 
   beforeEach(() => {
     spawnFn = vi.fn();
+    mockFindAgentByTask.mockReset();
+    mockGetDelivery.mockReset();
   });
 
   afterEach(() => vi.restoreAllMocks());
@@ -201,6 +205,80 @@ describe('DispatchLoop', () => {
 
       // No branch → no delivery → worktree preserved (not released in deliver path)
       expect(mockMonitorDelivery).not.toHaveBeenCalled();
+    });
+
+    it('skips spawn when task already has completed agent with branch', async () => {
+      mockFindAgentByTask.mockReturnValue({
+        id: 'existing-a1',
+        status: 'completed',
+        branch: 'agent/t1',
+      });
+      mockGetDelivery.mockReturnValue(null);
+      mockInitiateDelivery.mockReturnValue({
+        agent_id: 'existing-a1',
+        task_id: 't1',
+        branch: 'agent/t1',
+      });
+      mockMonitorDelivery.mockResolvedValue('merged');
+
+      await makeLoop().executeWave({ wave: 1, taskIds: ['t1'] });
+
+      expect(spawnFn).not.toHaveBeenCalled();
+      expect(mockInitiateDelivery).toHaveBeenCalledWith(
+        fakeDb,
+        'existing-a1',
+        't1',
+        'agent/t1',
+        projectDir
+      );
+      expect(mockMonitorDelivery).toHaveBeenCalled();
+    });
+
+    it('skips task entirely when delivery already merged', async () => {
+      mockFindAgentByTask.mockReturnValue({
+        id: 'existing-a1',
+        status: 'completed',
+        branch: 'agent/t1',
+      });
+      mockGetDelivery.mockReturnValue({ status: 'merged', agent_id: 'existing-a1', task_id: 't1' });
+
+      await makeLoop().executeWave({ wave: 1, taskIds: ['t1'] });
+
+      expect(spawnFn).not.toHaveBeenCalled();
+      expect(mockInitiateDelivery).not.toHaveBeenCalled();
+      expect(mockMonitorDelivery).not.toHaveBeenCalled();
+    });
+
+    it('skips task entirely when delivery stalled', async () => {
+      mockFindAgentByTask.mockReturnValue({
+        id: 'existing-a1',
+        status: 'completed',
+        branch: 'agent/t1',
+      });
+      mockGetDelivery.mockReturnValue({
+        status: 'stalled',
+        agent_id: 'existing-a1',
+        task_id: 't1',
+      });
+
+      await makeLoop().executeWave({ wave: 1, taskIds: ['t1'] });
+
+      expect(spawnFn).not.toHaveBeenCalled();
+      expect(mockInitiateDelivery).not.toHaveBeenCalled();
+      expect(mockMonitorDelivery).not.toHaveBeenCalled();
+    });
+
+    it('spawns normally when prior agent failed', async () => {
+      mockFindAgentByTask.mockReturnValue({ id: 'prev', status: 'failed', branch: null });
+      mockGetDelivery.mockReturnValue(null);
+      spawnFn.mockResolvedValue({ agentId: 'a1', taskId: 't1', branch: 'agent/t1' });
+      mockGetAgent.mockReturnValue({ status: 'completed' });
+      mockInitiateDelivery.mockReturnValue({ agent_id: 'a1', task_id: 't1' });
+      mockMonitorDelivery.mockResolvedValue('merged');
+
+      await makeLoop().executeWave({ wave: 1, taskIds: ['t1'] });
+
+      expect(spawnFn).toHaveBeenCalledWith('t1');
     });
   });
 

--- a/src/modules/agents/dispatch-loop.ts
+++ b/src/modules/agents/dispatch-loop.ts
@@ -5,7 +5,7 @@ import type { BrainConfig, Embedder, InboxItem } from '../../types.js';
 import type { WaveAssignment } from '../pm/engine/dependency.js';
 import type { TaskStatus } from '../pm/types.js';
 import { getRawDb, sleep } from '../../utils/db.js';
-import { getAgent } from './data.js';
+import { findAgentByTask, getAgent } from './data.js';
 import { getDeliveryForTask, initiateDelivery, type DeliveryRecord } from './delivery.js';
 import { releaseWorktree } from './worktree.js';
 import { monitorDelivery, type DeliveryOutcome } from './delivery-monitor.js';
@@ -110,6 +110,32 @@ export class DispatchLoop {
     'stalled',
     'redispatched',
   ]);
+
+  /** Delivery statuses where all work (including monitoring) is finished. */
+  private static FINAL_STATUSES = new Set(['merged', 'delivered', 'stalled', 'redispatched']);
+
+  /**
+   * Check whether a task can be skipped or fast-forwarded based on existing
+   * agent/delivery state. Returns:
+   *  - 'skip': task is already fully delivered; do nothing
+   *  - { agentId, branch }: completed agent exists; skip spawn and deliver
+   *  - null: no completed agent; proceed with normal spawn
+   */
+  private idempotentCheck(
+    taskId: string
+  ): 'skip' | { agentId: string; branch: string | undefined } | null {
+    const delivery = getDeliveryForTask(this.rawDb, taskId);
+    if (delivery && DispatchLoop.FINAL_STATUSES.has(delivery.status)) {
+      return 'skip';
+    }
+
+    const agent = findAgentByTask(this.rawDb, taskId);
+    if (agent && agent.status === 'completed' && agent.branch) {
+      return { agentId: agent.id, branch: agent.branch };
+    }
+
+    return null;
+  }
 
   /**
    * Push branch and create PR for a completed agent.
@@ -241,6 +267,19 @@ export class DispatchLoop {
     const failedTaskIds: string[] = [];
 
     const agentTasks = wave.taskIds.map(async (taskId) => {
+      const existing = this.idempotentCheck(taskId);
+      if (existing === 'skip') {
+        process.stderr.write(`[dispatch-loop] ${taskId} already delivered, skipping\n`);
+        return;
+      }
+      if (existing) {
+        process.stderr.write(
+          `[dispatch-loop] ${taskId} has completed agent ${existing.agentId}, skipping spawn\n`
+        );
+        deliveries.push(this.deliverAndCleanup(existing.agentId, taskId, existing.branch));
+        return;
+      }
+
       await semaphore.acquire();
 
       let spawnResult: SpawnResult;


### PR DESCRIPTION
Dispatch-loop now skips spawn for tasks with completed agents, short-circuiting to delivery (or skipping entirely if already merged/delivered/stalled/redispatched). Fixes duplicate agent records and wasted work from repeated dispatches during workstream retry runs.

Agent: `d410f71f-8a04-4829-8466-17523720c3e0`