### PR TITLE
Use local tsx binary directly in integration tests

### DIFF
--- a/__tests__/integration/cli.test.ts
+++ b/__tests__/integration/cli.test.ts
@@ -5,7 +5,8 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 const PROJECT_ROOT = join(import.meta.dirname, '..', '..');
-const CLI = `npx tsx ${join(PROJECT_ROOT, 'src', 'cli.ts')}`;
+const TSX_BIN = join(PROJECT_ROOT, 'node_modules', '.bin', 'tsx');
+const CLI = `${TSX_BIN} ${join(PROJECT_ROOT, 'src', 'cli.ts')}`;
 
 let tmpDir: string;
 let notesDir: string;

--- a/__tests__/integration/pm-cli.test.ts
+++ b/__tests__/integration/pm-cli.test.ts
@@ -5,7 +5,8 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 const PROJECT_ROOT = join(import.meta.dirname, '..', '..');
-const CLI = `npx tsx ${join(PROJECT_ROOT, 'src', 'cli.ts')}`;
+const TSX_BIN = join(PROJECT_ROOT, 'node_modules', '.bin', 'tsx');
+const CLI = `${TSX_BIN} ${join(PROJECT_ROOT, 'src', 'cli.ts')}`;
 
 let tmpDir: string;
 let notesDir: string;

--- a/__tests__/integration/pm-v12.test.ts
+++ b/__tests__/integration/pm-v12.test.ts
@@ -5,7 +5,8 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 const PROJECT_ROOT = join(import.meta.dirname, '..', '..');
-const CLI = `npx tsx ${join(PROJECT_ROOT, 'src', 'cli.ts')}`;
+const TSX_BIN = join(PROJECT_ROOT, 'node_modules', '.bin', 'tsx');
+const CLI = `${TSX_BIN} ${join(PROJECT_ROOT, 'src', 'cli.ts')}`;
 
 let tmpDir: string;
 let notesDir: string;

--- a/__tests__/integration/pm-v9.test.ts
+++ b/__tests__/integration/pm-v9.test.ts
@@ -5,7 +5,8 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 const PROJECT_ROOT = join(import.meta.dirname, '..', '..');
-const CLI = `npx tsx ${join(PROJECT_ROOT, 'src', 'cli.ts')}`;
+const TSX_BIN = join(PROJECT_ROOT, 'node_modules', '.bin', 'tsx');
+const CLI = `${TSX_BIN} ${join(PROJECT_ROOT, 'src', 'cli.ts')}`;
 
 let tmpDir: string;
 let notesDir: string;


### PR DESCRIPTION
## Summary
- Replaces `npx tsx` with absolute path to `node_modules/.bin/tsx` in 4 integration test files
- Fixes intermittent CI failure where parallel shards raced to install tsx into the global _npx cache
- 76/76 integration tests pass locally

## Why
Integration tests spawn the CLI with `execSync(CLI, { cwd: tmpDir })`. The tmpDir has no node_modules, so `npx` falls back to the global _npx cache and auto-installs tsx on every run. With 2 parallel integration shards in CI, one shard would install while another tried to execvp a half-unpacked esbuild — ENOENT on tsx's bin entry. This was the "flake" blocking #176 and multiple prior PRs.

## Test plan
- [x] All 4 affected integration tests pass locally
- [ ] CI passes consistently on this PR (the goal)