### PR TITLE
Add brain_pm_task_release / _complete and reason on _update

### DIFF
--- a/src/modules/pm/commands/orchestration.ts
+++ b/src/modules/pm/commands/orchestration.ts
@@ -3,6 +3,9 @@ import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { Command } from '@commander-js/extra-typings';
 import { withBrain } from '../../../services/brain-service.js';
+import type { BrainService } from '../../../services/brain-service.js';
+import type { Embedder } from '../../../types.js';
+import type { BrainConfig } from '../../../types.js';
 import { formatError } from '../errors.js';
 import { resolveWorkstreamFilter } from '../ids.js';
 import type { Result } from '../errors.js';
@@ -55,6 +58,121 @@ export function resolveWorkstreamByName(
     'INVALID_INPUT',
     `No workstream matching "${input}". Use a number, display ID, or name. Run "brain pm workstream list" to see options.`
   );
+}
+
+export interface CompleteTaskOptions {
+  token?: string;
+  summary?: string;
+  actorType?: 'cli' | 'mcp' | 'agent';
+  actorId?: string | null;
+  sessionId?: string | null;
+  onTransition?: (from: TaskStatus, to: TaskStatus) => void;
+}
+
+export interface CompleteTaskResult<T = Record<string, unknown>> {
+  task: T;
+  newlyEligible: string[];
+}
+
+type CompleteTaskService = Pick<BrainService, 'db' | 'config' | 'embedder'> & {
+  db: BrainDB;
+  config: BrainConfig;
+  embedder: Embedder;
+};
+
+/**
+ * Core completion logic shared by the CLI `pm complete` command and the
+ * `brain_pm_task_complete` MCP tool. Drives the pending→claimed→in-progress→done
+ * transition, optionally validates a claim token, writes a summary file,
+ * records activity, and computes newly eligible downstream tasks.
+ */
+export async function completeTask(
+  svc: CompleteTaskService,
+  displayId: string,
+  opts: CompleteTaskOptions = {}
+): Promise<Result<CompleteTaskResult>> {
+  const taskResult = getTask(svc.db, displayId);
+  if (!taskResult.ok) return taskResult;
+
+  const transitions: Array<[TaskStatus, TaskStatus]> = [];
+  let currentStatus = taskResult.data.status;
+
+  if (currentStatus === 'pending') {
+    const claimResult = await updateTaskStatus(
+      svc.db,
+      svc.config,
+      svc.embedder,
+      displayId,
+      'claimed' as TaskStatus
+    );
+    if (!claimResult.ok) return claimResult;
+    transitions.push(['pending', 'claimed']);
+    currentStatus = 'claimed';
+  }
+
+  if (currentStatus === 'claimed') {
+    const startResult = await updateTaskStatus(
+      svc.db,
+      svc.config,
+      svc.embedder,
+      displayId,
+      'in-progress' as TaskStatus
+    );
+    if (!startResult.ok) return startResult;
+    transitions.push(['claimed', 'in-progress']);
+  }
+
+  if (opts.token) {
+    const storedToken = taskResult.data.claim_token;
+    if (!storedToken) {
+      return fail('INVALID_CLAIM_TOKEN', 'Task has no active claim');
+    }
+    const tokenCheck = validateClaimToken(storedToken, opts.token);
+    if (!tokenCheck.ok) return tokenCheck;
+  }
+
+  for (const [from, to] of transitions) {
+    opts.onTransition?.(from, to);
+  }
+
+  const statusResult = await updateTaskStatus(
+    svc.db,
+    svc.config,
+    svc.embedder,
+    displayId,
+    'done' as TaskStatus
+  );
+  if (!statusResult.ok) return statusResult;
+
+  if (opts.summary) {
+    const notes = getPmNotes(svc.db, 'task', { display_id: displayId });
+    if (notes.length > 0 && notes[0].contentDir) {
+      const contentDir = notes[0].contentDir;
+      if (!existsSync(contentDir)) {
+        mkdirSync(contentDir, { recursive: true });
+      }
+      writeFileSync(join(contentDir, 'summary.md'), opts.summary, 'utf-8');
+    }
+  }
+
+  const now = new Date().toISOString();
+  svc.db.addActivity({
+    id: randomUUID(),
+    noteIds: JSON.stringify([displayId]),
+    module: 'pm',
+    moduleInstance: taskResult.data.project,
+    activityType: 'task_completed',
+    actorType: opts.actorType ?? 'cli',
+    actorId: opts.actorId ?? null,
+    sessionId: opts.sessionId ?? null,
+    metadata: JSON.stringify({ display_id: displayId }),
+    outcome: 'done',
+    startedAt: now,
+    completedAt: now,
+  });
+
+  const newlyEligible = computeImpact(svc.db, taskResult.data.project, displayId);
+  return ok({ task: statusResult.data as unknown as Record<string, unknown>, newlyEligible });
 }
 
 export function createOrchestrationCommands(): Command[] {
@@ -407,123 +525,31 @@ export function createOrchestrationCommands(): Command[] {
     .action(async (id, opts) => {
       await withBrain(async (svc) => {
         const displayId = id.toUpperCase();
-
-        const taskResult = getTask(svc.db, displayId);
-        if (!taskResult.ok) {
-          process.stderr.write(formatError(taskResult.error, !!opts.json) + '\n');
-          process.exitCode = 1;
-          return;
-        }
-
-        let currentStatus = taskResult.data.status;
-
-        if (currentStatus === 'pending') {
-          const claimResult = await updateTaskStatus(
-            svc.db,
-            svc.config,
-            svc.embedder,
-            displayId,
-            'claimed' as TaskStatus
-          );
-          if (!claimResult.ok) {
-            process.stderr.write(formatError(claimResult.error, !!opts.json) + '\n');
-            process.exitCode = 1;
-            return;
-          }
-          if (!opts.json) process.stdout.write(`${displayId}: pending → claimed\n`);
-          currentStatus = 'claimed';
-        }
-
-        if (currentStatus === 'claimed') {
-          const startResult = await updateTaskStatus(
-            svc.db,
-            svc.config,
-            svc.embedder,
-            displayId,
-            'in-progress' as TaskStatus
-          );
-          if (!startResult.ok) {
-            process.stderr.write(formatError(startResult.error, !!opts.json) + '\n');
-            process.exitCode = 1;
-            return;
-          }
-          if (!opts.json) process.stdout.write(`${displayId}: claimed → in-progress\n`);
-        }
-
-        if (opts.token) {
-          const storedToken = taskResult.data.claim_token;
-          if (!storedToken) {
-            process.stderr.write(
-              formatError(
-                { error: true, code: 'INVALID_CLAIM_TOKEN', message: 'Task has no active claim' },
-                !!opts.json
-              ) + '\n'
-            );
-            process.exitCode = 1;
-            return;
-          }
-          const tokenCheck = validateClaimToken(storedToken, opts.token);
-          if (!tokenCheck.ok) {
-            process.stderr.write(formatError(tokenCheck.error, !!opts.json) + '\n');
-            process.exitCode = 1;
-            return;
-          }
-        }
-
-        const statusResult = await updateTaskStatus(
-          svc.db,
-          svc.config,
-          svc.embedder,
-          displayId,
-          'done' as TaskStatus
-        );
-        if (!statusResult.ok) {
-          process.stderr.write(formatError(statusResult.error, !!opts.json) + '\n');
-          process.exitCode = 1;
-          return;
-        }
-
-        if (opts.summary) {
-          const notes = getPmNotes(svc.db, 'task', { display_id: displayId });
-          if (notes.length > 0 && notes[0].contentDir) {
-            const contentDir = notes[0].contentDir;
-            if (!existsSync(contentDir)) {
-              mkdirSync(contentDir, { recursive: true });
-            }
-            writeFileSync(join(contentDir, 'summary.md'), opts.summary, 'utf-8');
-          }
-        }
-
-        const now = new Date().toISOString();
-        svc.db.addActivity({
-          id: randomUUID(),
-          noteIds: JSON.stringify([displayId]),
-          module: 'pm',
-          moduleInstance: taskResult.data.project,
-          activityType: 'task_completed',
+        const result = await completeTask(svc, displayId, {
+          token: opts.token,
+          summary: opts.summary,
           actorType: 'cli',
-          actorId: null,
-          sessionId: null,
-          metadata: JSON.stringify({ display_id: displayId }),
-          outcome: 'done',
-          startedAt: now,
-          completedAt: now,
+          onTransition: opts.json
+            ? undefined
+            : (from, to) => process.stdout.write(`${displayId}: ${from} → ${to}\n`),
         });
 
-        const impact = computeImpact(svc.db, taskResult.data.project, displayId);
+        if (!result.ok) {
+          process.stderr.write(formatError(result.error, !!opts.json) + '\n');
+          process.exitCode = 1;
+          return;
+        }
 
-        const output = {
-          ...statusResult.data,
-          newlyEligible: impact,
-        };
+        const { task, newlyEligible } = result.data;
+        const output = { ...task, newlyEligible };
 
         if (opts.json) {
           process.stdout.write(JSON.stringify(output, null, 2) + '\n');
         } else {
           process.stdout.write(`Completed ${displayId}\n`);
-          if (impact.length > 0) {
+          if (newlyEligible.length > 0) {
             process.stderr.write('\nNewly eligible tasks:\n');
-            for (const impactId of impact) {
+            for (const impactId of newlyEligible) {
               const impactTask = getTask(svc.db, impactId);
               if (impactTask.ok) {
                 const title = impactTask.data.title ? ` ${impactTask.data.title}` : '';

--- a/src/modules/pm/commands/task.ts
+++ b/src/modules/pm/commands/task.ts
@@ -965,7 +965,7 @@ function readTaskBodyFromDb(db: BrainDB, displayId: string): string {
   return readTaskBody(notes[0]);
 }
 
-async function updateTaskMetadataFields(
+export async function updateTaskMetadataFields(
   db: BrainDB,
   config: BrainConfig,
   embedder: Embedder,

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -10,6 +10,9 @@ import { indexSingleFile } from '../services/indexing.js';
 import { slugify } from '../utils.js';
 import { getTask, listTasks, createTask } from '../modules/pm/data/task-ops.js';
 import { updateTaskStatus } from '../modules/pm/data/task-ops.js';
+import { updateTaskMetadataFields } from '../modules/pm/commands/task.js';
+import { completeTask } from '../modules/pm/commands/orchestration.js';
+import { validateTransition } from '../modules/pm/engine/state-machine.js';
 import { listWorkstreams, createWorkstream } from '../modules/pm/data/workstream-ops.js';
 import { computeEligible, computeWaves } from '../modules/pm/engine/dependency.js';
 import { resolveProject, getPmNotes } from '../modules/pm/data/queries.js';
@@ -148,12 +151,16 @@ function registerPmTools(server: McpServer, svc: BrainServiceClass): void {
 
   server.tool(
     'brain_pm_task_update',
-    'Update a task status (e.g. backlog, ready, in-progress, review, done)',
+    'Update a task status (e.g. pending, claimed, in-progress, blocked, done). When status=blocked and reason is provided, the reason is stored in block_reason metadata.',
     {
       displayId: z.string().describe('Task display ID'),
       status: z.string().describe('New status'),
+      reason: z
+        .string()
+        .optional()
+        .describe('Reason for the transition (stored as block_reason when status=blocked)'),
     },
-    async ({ displayId, status }) => {
+    async ({ displayId, status, reason }) => {
       const result = await updateTaskStatus(
         svc.db,
         svc.config,
@@ -162,7 +169,61 @@ function registerPmTools(server: McpServer, svc: BrainServiceClass): void {
         status as TaskStatus
       );
       if (!result.ok) return errorResult(result.error.message);
+      if (reason && status === 'blocked') {
+        const metaResult = await updateTaskMetadataFields(
+          svc.db,
+          svc.config,
+          svc.embedder,
+          displayId,
+          { block_reason: reason }
+        );
+        if (!metaResult.ok) return errorResult(metaResult.error.message);
+        return textResult(metaResult.data);
+      }
       return textResult(result.data);
+    }
+  );
+
+  server.tool(
+    'brain_pm_task_release',
+    'Release a task claim (claimed → pending). Clears claim_token and claimed_at. Use when an orphaned claim is blocking re-dispatch.',
+    {
+      displayId: z.string().describe('Task display ID'),
+    },
+    async ({ displayId }) => {
+      const taskResult = getTask(svc.db, displayId);
+      if (!taskResult.ok) return errorResult(taskResult.error.message);
+      const transResult = validateTransition(taskResult.data.status, 'pending');
+      if (!transResult.ok) return errorResult(transResult.error.message);
+      const metaResult = await updateTaskMetadataFields(
+        svc.db,
+        svc.config,
+        svc.embedder,
+        displayId,
+        { status: 'pending', claim_token: '', claimed_at: '' }
+      );
+      if (!metaResult.ok) return errorResult(metaResult.error.message);
+      return textResult(metaResult.data);
+    }
+  );
+
+  server.tool(
+    'brain_pm_task_complete',
+    'Mark task done with full impact analysis. Transitions pending→claimed→in-progress→done, records activity, returns newlyEligible downstream tasks.',
+    {
+      displayId: z.string().describe('Task display ID'),
+      summary: z.string().optional().describe('Completion summary (written to task summary.md)'),
+      token: z.string().optional().describe('Claim token to validate'),
+    },
+    async ({ displayId, summary, token }) => {
+      const result = await completeTask(svc, displayId, {
+        token,
+        summary,
+        actorType: 'mcp',
+      });
+      if (!result.ok) return errorResult(result.error.message);
+      const { task, newlyEligible } = result.data;
+      return textResult({ ...(task as object), newlyEligible });
     }
   );
 


### PR DESCRIPTION
## Summary
- Closes the MCP gap that forced CLI fallbacks for routine PM task mutations
- New tools: `brain_pm_task_release`, `brain_pm_task_complete`
- `brain_pm_task_update` now accepts an optional `reason` (stored as `block_reason` when status=blocked)
- Refactor: extracted `completeTask()` from CLI command into a shared helper so CLI + MCP drive the same lifecycle path

## Test plan
- [ ] CI green
- [ ] After merge + MCP rebuild, `brain_pm_task_release VNM-XX.YY` clears stale claim_token and returns task to pending
- [ ] `brain_pm_task_complete` returns `newlyEligible` impact list
- [ ] `brain_pm_task_update` with `status=blocked, reason="…"` writes block_reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)