### PR TITLE
Untrack .claude/scheduled_tasks.lock

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"bc19f75e-be54-4cc4-9d36-948a700430e1","pid":83307,"acquiredAt":1776813339634}


### PR DESCRIPTION
## Summary
- The path is gitignored but was tracked from before the ignore was added
- Has been showing as deleted in git status across sessions for weeks
- Remove from the index only; file regenerates locally as needed

## Test plan
- [x] git status no longer reports the file as deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)