### PR TITLE
Auto-reclaim worktrees and queue dispatch on budget exhaustion (VNM-45.38)

### DIFF
--- a/__tests__/modules/agents/worktree.test.ts
+++ b/__tests__/modules/agents/worktree.test.ts
@@ -1,14 +1,26 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import Database from 'better-sqlite3';
-import { agentsMigrationV1, agentsMigrationV2 } from '../../../src/modules/agents/schema.js';
+import {
+  agentsMigrationV1,
+  agentsMigrationV2,
+  agentsMigrationV3,
+  agentsMigrationV4,
+} from '../../../src/modules/agents/schema.js';
 import {
   allocateWorktree,
   releaseWorktree,
   checkWorktreePath,
   cleanupStaleAllocations,
   cleanupOrphanRemoteBranches,
+  reclaimTerminatedAllocations,
+  WorktreeBudgetExhaustedError,
 } from '../../../src/modules/agents/worktree.js';
-import { getWorktreeAllocations } from '../../../src/modules/agents/data.js';
+import {
+  createAgent,
+  getWorktreeAllocations,
+  updateAgentStatus,
+} from '../../../src/modules/agents/data.js';
+import { recordDelivery } from '../../../src/modules/agents/delivery.js';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -16,6 +28,8 @@ function makeDb(): ReturnType<typeof Database> {
   const db = new Database(':memory:');
   agentsMigrationV1.up(db);
   agentsMigrationV2.up(db);
+  agentsMigrationV3.up(db);
+  agentsMigrationV4.up(db);
   return db;
 }
 
@@ -154,7 +168,7 @@ describe('worktree lifecycle', () => {
       expect(allocs[0].task_id).toBe('VNM-09.02');
     });
 
-    it('enforces budget — throws when limit reached', () => {
+    it('enforces budget — throws WorktreeBudgetExhaustedError when limit reached', () => {
       allocateWorktree(db, '/repo', {
         taskId: 'VNM-09.01',
         workstream: 'ws-1',
@@ -178,7 +192,41 @@ describe('worktree lifecycle', () => {
           basePath: '.worktrees',
           budget: 2,
         })
-      ).toThrow('Worktree budget exhausted: 2/2');
+      ).toThrow(WorktreeBudgetExhaustedError);
+    });
+
+    it('reclaims terminated agents before counting budget', () => {
+      // First allocation: agent will reach terminal state
+      allocateWorktree(db, '/repo', {
+        taskId: 'VNM-09.01',
+        workstream: 'ws-1',
+        claimToken: 'tok-1',
+        basePath: '.worktrees',
+        budget: 1,
+      });
+      const agentId = createAgent(db, {
+        name: 'agent-1',
+        parent: 'test',
+        brain_task: 'VNM-09.01',
+      });
+      updateAgentStatus(db, agentId, 'completed');
+
+      vi.clearAllMocks();
+      mockExistsSync.mockReturnValue(true);
+
+      // Budget is 1; allocation succeeds because the prior agent is reclaimed
+      const result = allocateWorktree(db, '/repo', {
+        taskId: 'VNM-09.02',
+        workstream: 'ws-2',
+        claimToken: 'tok-2',
+        basePath: '.worktrees',
+        budget: 1,
+      });
+
+      expect(result.worktreePath).toContain('VNM-09.02');
+      const allocs = getWorktreeAllocations(db);
+      expect(allocs).toHaveLength(1);
+      expect(allocs[0].task_id).toBe('VNM-09.02');
     });
 
     it('throws when workstream is empty', () => {
@@ -394,6 +442,128 @@ describe('worktree lifecycle', () => {
     it('returns empty array when there are no allocations', () => {
       const removed = cleanupStaleAllocations(db, '/repo');
       expect(removed).toHaveLength(0);
+    });
+  });
+
+  // ── reclaimTerminatedAllocations ───────────────────────────────────────────
+
+  describe('reclaimTerminatedAllocations', () => {
+    function allocateAndAttachAgent(taskId: string, status: 'completed' | 'failed' | 'abandoned') {
+      allocateWorktree(db, '/repo', {
+        taskId,
+        workstream: 'ws-x',
+        claimToken: `tok-${taskId}`,
+        basePath: '.worktrees',
+        budget: 5,
+      });
+      const agentId = createAgent(db, {
+        name: `agent-${taskId}`,
+        parent: 'test',
+        brain_task: taskId,
+      });
+      updateAgentStatus(db, agentId, status);
+      return agentId;
+    }
+
+    it('reclaims allocations whose agents are completed/failed/abandoned', () => {
+      // Allocate all three first (no agents yet, so no cascading reclaim)
+      for (const id of ['VNM-09.01', 'VNM-09.02', 'VNM-09.03']) {
+        allocateWorktree(db, '/repo', {
+          taskId: id,
+          workstream: 'ws-x',
+          claimToken: `tok-${id}`,
+          basePath: '.worktrees',
+          budget: 5,
+        });
+      }
+      const statuses: Array<'completed' | 'failed' | 'abandoned'> = [
+        'completed',
+        'failed',
+        'abandoned',
+      ];
+      ['VNM-09.01', 'VNM-09.02', 'VNM-09.03'].forEach((id, i) => {
+        const agentId = createAgent(db, { name: `a-${id}`, parent: 't', brain_task: id });
+        updateAgentStatus(db, agentId, statuses[i]);
+      });
+
+      vi.clearAllMocks();
+      mockExistsSync.mockReturnValue(true);
+
+      const reclaimed = reclaimTerminatedAllocations(db, '/repo');
+      expect(reclaimed.sort()).toEqual(['VNM-09.01', 'VNM-09.02', 'VNM-09.03']);
+      expect(getWorktreeAllocations(db)).toHaveLength(0);
+    });
+
+    it('preserves allocations whose agents are still active or pending', () => {
+      allocateWorktree(db, '/repo', {
+        taskId: 'VNM-09.01',
+        workstream: 'ws-1',
+        claimToken: 'tok-1',
+        basePath: '.worktrees',
+        budget: 5,
+      });
+      const agentId = createAgent(db, {
+        name: 'agent-1',
+        parent: 'test',
+        brain_task: 'VNM-09.01',
+      });
+      updateAgentStatus(db, agentId, 'active');
+
+      vi.clearAllMocks();
+      mockExistsSync.mockReturnValue(true);
+
+      const reclaimed = reclaimTerminatedAllocations(db, '/repo');
+      expect(reclaimed).toHaveLength(0);
+      expect(getWorktreeAllocations(db)).toHaveLength(1);
+    });
+
+    it('preserves allocations whose owning agent has no record', () => {
+      allocateWorktree(db, '/repo', {
+        taskId: 'VNM-09.01',
+        workstream: 'ws-1',
+        claimToken: 'tok-1',
+        basePath: '.worktrees',
+        budget: 5,
+      });
+
+      vi.clearAllMocks();
+      mockExistsSync.mockReturnValue(true);
+
+      const reclaimed = reclaimTerminatedAllocations(db, '/repo');
+      expect(reclaimed).toHaveLength(0);
+      expect(getWorktreeAllocations(db)).toHaveLength(1);
+    });
+
+    it('preserves allocations whose delivery is still in flight', () => {
+      const agentId = allocateAndAttachAgent('VNM-09.01', 'completed');
+      recordDelivery(db, agentId, {
+        status: 'pr-open',
+        task_id: 'VNM-09.01',
+        branch: 'agent/ws-x/VNM-09.01',
+      });
+
+      vi.clearAllMocks();
+      mockExistsSync.mockReturnValue(true);
+
+      const reclaimed = reclaimTerminatedAllocations(db, '/repo');
+      expect(reclaimed).toHaveLength(0);
+      expect(getWorktreeAllocations(db)).toHaveLength(1);
+    });
+
+    it('reclaims allocations whose delivery has finalized', () => {
+      const agentId = allocateAndAttachAgent('VNM-09.01', 'completed');
+      recordDelivery(db, agentId, {
+        status: 'merged',
+        task_id: 'VNM-09.01',
+        branch: 'agent/ws-x/VNM-09.01',
+      });
+
+      vi.clearAllMocks();
+      mockExistsSync.mockReturnValue(true);
+
+      const reclaimed = reclaimTerminatedAllocations(db, '/repo');
+      expect(reclaimed).toEqual(['VNM-09.01']);
+      expect(getWorktreeAllocations(db)).toHaveLength(0);
     });
   });
 

--- a/__tests__/server/dispatch.test.ts
+++ b/__tests__/server/dispatch.test.ts
@@ -33,9 +33,13 @@ vi.mock('../../src/modules/agents/dispatch-context.js', () => ({
   formatDispatchBrief: vi.fn().mockReturnValue('test brief'),
 }));
 
-vi.mock('../../src/modules/agents/worktree.js', () => ({
-  allocateWorktree: vi.fn(),
-}));
+vi.mock('../../src/modules/agents/worktree.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/modules/agents/worktree.js')>();
+  return {
+    ...actual,
+    allocateWorktree: vi.fn(),
+  };
+});
 
 vi.mock('../../src/modules/agents/data.js', () => ({
   createAgent: vi.fn().mockReturnValue('agent-001'),
@@ -71,7 +75,8 @@ vi.mock('../../src/services/indexing.js', () => ({
 // Lazy imports for mocked modules
 const { pullNextTask } = await import('../../src/modules/agents/task-pull.js');
 const { buildWorkerDispatchFromPull } = await import('../../src/modules/agents/coordinator.js');
-const { allocateWorktree } = await import('../../src/modules/agents/worktree.js');
+const { allocateWorktree, WorktreeBudgetExhaustedError } =
+  await import('../../src/modules/agents/worktree.js');
 const { getPmNotes } = await import('../../src/modules/pm/data/queries.js');
 const fs = await import('node:fs');
 const { dispatchTask } = await import('../../src/server/dispatch.js');
@@ -193,17 +198,44 @@ describe('dispatch', () => {
       vi.mocked(fs.readFileSync).mockReturnValue(claimedFileContent);
     }
 
-    it('releases claim when worktree allocation fails', async () => {
+    it('releases claim and rethrows when worktree allocation fails', async () => {
       vi.mocked(pullNextTask).mockResolvedValue(makePullResult());
       vi.mocked(buildWorkerDispatchFromPull).mockReturnValue(
         makeWorkerDispatch({ routing: { ...defaultRouting, isolation: 'worktree' } })
       );
       vi.mocked(allocateWorktree).mockImplementation(() => {
-        throw new Error('Worktree budget exhausted: 3/3 allocated');
+        throw new Error('git worktree add: fatal');
       });
       setupNoteLookup();
 
-      await expect(dispatchTask(mockSvc, {})).rejects.toThrow('Worktree budget exhausted');
+      await expect(dispatchTask(mockSvc, {})).rejects.toThrow('git worktree add: fatal');
+
+      expect(fs.writeFileSync).toHaveBeenCalled();
+      const written = vi.mocked(fs.writeFileSync).mock.calls[0]?.[1] as string;
+      expect(written).toContain('status: pending');
+      expect(written).not.toMatch(/^claim_token:/m);
+      expect(written).not.toMatch(/^claimed_at:/m);
+    });
+
+    it('returns queued result and releases claim when worktree budget is exhausted', async () => {
+      vi.mocked(pullNextTask).mockResolvedValue(makePullResult());
+      vi.mocked(buildWorkerDispatchFromPull).mockReturnValue(
+        makeWorkerDispatch({ routing: { ...defaultRouting, isolation: 'worktree' } })
+      );
+      vi.mocked(allocateWorktree).mockImplementation(() => {
+        throw new WorktreeBudgetExhaustedError(3, 3);
+      });
+      setupNoteLookup();
+
+      const result = await dispatchTask(mockSvc, {});
+
+      expect(result).toEqual({
+        status: 'queued',
+        taskId: 'VNM-99.01',
+        reason: 'Worktree budget exhausted: 3/3 allocated',
+        allocated: 3,
+        budget: 3,
+      });
 
       expect(fs.writeFileSync).toHaveBeenCalled();
       const written = vi.mocked(fs.writeFileSync).mock.calls[0]?.[1] as string;

--- a/src/modules/agents/worktree.ts
+++ b/src/modules/agents/worktree.ts
@@ -5,8 +5,44 @@ import {
   allocateWorktree as dbAllocate,
   releaseWorktree as dbRelease,
   getWorktreeAllocations,
+  findAgentByTask,
 } from './data.js';
-import type { WorktreeAllocation, AllocateWorktreeInput } from './types.js';
+import { getDeliveryForTask } from './delivery.js';
+import { getRawDb } from '../../utils/db.js';
+import type Database from 'better-sqlite3';
+import type { BrainDB } from '../../services/brain-db.js';
+import type { WorktreeAllocation, AllocateWorktreeInput, AgentStatus } from './types.js';
+
+/**
+ * Thrown by {@link allocateWorktree} when no worktree slot is available even
+ * after stale and terminated-agent reclaim. Callers can catch this to surface
+ * a structured "queued" response instead of treating it as a hard failure.
+ */
+export class WorktreeBudgetExhaustedError extends Error {
+  constructor(
+    public readonly allocated: number,
+    public readonly budget: number
+  ) {
+    super(`Worktree budget exhausted: ${allocated}/${budget} allocated`);
+    this.name = 'WorktreeBudgetExhaustedError';
+  }
+}
+
+const TERMINAL_AGENT_STATUSES: ReadonlySet<AgentStatus> = new Set([
+  'completed',
+  'failed',
+  'abandoned',
+]);
+
+const ACTIVE_DELIVERY_STATUSES: ReadonlySet<string> = new Set([
+  'in-progress',
+  'pushed',
+  'pr-open',
+  'pr-failed',
+  'push-failed',
+  'conflicted',
+  'review-paused',
+]);
 
 export interface AllocateWorktreeOptions {
   taskId: string;
@@ -70,12 +106,14 @@ export function allocateWorktree(
   const budget = opts.budget ?? DEFAULT_BUDGET;
   const basePath = opts.basePath ?? DEFAULT_BASE_PATH;
 
-  // Clean up stale allocations before checking budget
+  // Reclaim slots before checking budget: first stale paths, then allocations
+  // whose owning agent has reached a terminal state without an in-flight delivery.
   cleanupStaleAllocations(db, projectRoot);
+  reclaimTerminatedAllocations(db, projectRoot);
 
   const currentAllocations = getWorktreeAllocations(db);
   if (currentAllocations.length >= budget) {
-    throw new Error(`Worktree budget exhausted: ${currentAllocations.length}/${budget} allocated`);
+    throw new WorktreeBudgetExhaustedError(currentAllocations.length, budget);
   }
 
   const branch = `agent/${opts.workstream}/${opts.taskId}`;
@@ -169,6 +207,48 @@ export function checkWorktreePath(expectedPath: string): CheckWorktreeResult {
   const boundary = expected + sep;
   const inWorktree = normalizedActual === expected || normalizedActual.startsWith(boundary);
   return { inWorktree, expected, actual };
+}
+
+/**
+ * Release allocations whose owning agent has reached a terminal status
+ * (completed/failed/abandoned) and has no in-flight delivery. Used to reclaim
+ * worktree budget when prior agents finished without the dispatch loop's
+ * cleanup hook running (e.g., individual `brain_agent_dispatch` calls or
+ * crash recovery).
+ *
+ * Allocations without an agent record, or whose agent is still pending/active,
+ * or whose delivery is mid-flight (push, PR, review) are left alone — releasing
+ * them would kill in-progress work.
+ */
+export function reclaimTerminatedAllocations(db: unknown, projectRoot: string): string[] {
+  const allocations = getWorktreeAllocations(db);
+  const reclaimed: string[] = [];
+  const rawDb = tryGetRawDb(db);
+
+  for (const allocation of allocations) {
+    const agent = findAgentByTask(db, allocation.task_id);
+    if (!agent) continue;
+    if (!TERMINAL_AGENT_STATUSES.has(agent.status)) continue;
+
+    if (rawDb) {
+      const delivery = getDeliveryForTask(rawDb, allocation.task_id);
+      if (delivery && ACTIVE_DELIVERY_STATUSES.has(delivery.status)) continue;
+    }
+
+    if (releaseWorktree(db, projectRoot, allocation.task_id)) {
+      reclaimed.push(allocation.task_id);
+    }
+  }
+
+  return reclaimed;
+}
+
+function tryGetRawDb(db: unknown): Database.Database | null {
+  try {
+    return getRawDb(db as BrainDB | Database.Database);
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/src/modules/workflow/runtime/context.ts
+++ b/src/modules/workflow/runtime/context.ts
@@ -468,6 +468,9 @@ export class WorkflowContext {
     if ('dryRun' in result) {
       throw new Error('dispatchTask returned dry-run result unexpectedly');
     }
+    if ('status' in result) {
+      throw new Error(`Dispatch queued for ${taskId}: ${result.reason}`);
+    }
 
     // Store routing metadata so session analytics can track model usage (best-effort)
     try {

--- a/src/server/dispatch.ts
+++ b/src/server/dispatch.ts
@@ -20,7 +20,7 @@ import {
 } from '../modules/agents/dispatch-context.js';
 import { replaceFrontmatterField } from '../utils.js';
 import { indexSingleFile } from '../services/indexing.js';
-import { allocateWorktree } from '../modules/agents/worktree.js';
+import { allocateWorktree, WorktreeBudgetExhaustedError } from '../modules/agents/worktree.js';
 import type { AllocateWorktreeResult } from '../modules/agents/worktree.js';
 import {
   createAgent,
@@ -115,6 +115,18 @@ export interface DispatchResult {
   prompt: string;
 }
 
+/**
+ * Returned when the worktree budget is exhausted. The PM task claim has been
+ * released, so the coordinator can poll and retry once a slot frees up.
+ */
+export interface QueuedDispatchResult {
+  status: 'queued';
+  taskId: string;
+  reason: string;
+  allocated: number;
+  budget: number;
+}
+
 export interface DryRunResult {
   taskId: string;
   prompt: string;
@@ -139,7 +151,7 @@ export interface ClaudeJsonResult {
 export async function dispatchTask(
   svc: BrainServiceClass,
   opts: DispatchOptions
-): Promise<DispatchResult | DryRunResult> {
+): Promise<DispatchResult | DryRunResult | QueuedDispatchResult> {
   const projectDir = resolveProjectDir(svc);
 
   const pullResult = opts.taskId
@@ -160,6 +172,15 @@ export async function dispatchTask(
           }\n`
         );
       });
+    }
+    if (err instanceof WorktreeBudgetExhaustedError) {
+      return {
+        status: 'queued',
+        taskId: pullResult.taskId,
+        reason: err.message,
+        allocated: err.allocated,
+        budget: err.budget,
+      };
     }
     throw err;
   }

--- a/src/server/orchestration.ts
+++ b/src/server/orchestration.ts
@@ -384,6 +384,9 @@ export class OrchestrationService {
           worktreeBudget: this.wipLimit,
           maxBudgetUsd: opts?.maxBudgetUsd,
         });
+        if ('status' in result && result.status === 'queued') {
+          throw new Error(`Dispatch queued for ${taskId}: ${result.reason}`);
+        }
         const r = result as DispatchResult;
         return { agentId: r.agentId, taskId: r.taskId, branch: r.branch };
       },


### PR DESCRIPTION
## Summary

- Auto-reclaim worktrees for completed/failed agents before counting against budget
- Return structured queued response instead of hard error when budget is exhausted
- Lets coordinators poll for capacity rather than catching dispatch exceptions

## Why

Closes VNM-45.38. Validated live this session — `brain_agent_dispatch` threw `Worktree budget exhausted: 3/3 allocated` even though one slot was held by an already-merged-and-deleted task (.44). Pre-fix, the only recovery was a manual `git worktree prune`. The reclaim path now handles that automatically; the queued response handles legitimate full-budget cases without crashing the caller.

## Test plan

- [ ] `npx tsc --noEmit` (passes locally)
- [ ] `npx eslint` (passes locally)
- [ ] New worktree.test.ts covers reclaim + queue behavior
- [ ] dispatch.test.ts updated for queued-response shape
- [ ] Unblocks VNM-56.46 (watchdog) downstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)