### PR TITLE
Recognize canonical signal marker in parseSignals (VNM-48.277)

### DIFF
--- a/__tests__/modules/workflow/runtime/signals.test.ts
+++ b/__tests__/modules/workflow/runtime/signals.test.ts
@@ -137,3 +137,42 @@ describe('parseSignals — bold markdown variants', () => {
     expect(parseSignals('review', 'planning', output)).toBe('needs_fixes');
   });
 });
+
+// --- Canonical signal marker tests ---
+
+describe('parseSignals — canonical signal marker', () => {
+  test('recognizes canonical needs_revision marker', () => {
+    const output = '## Summary\nLooks fine.\n\n<!-- signal: needs_revision -->';
+    expect(parseSignals('critic', 'planning', output)).toBe('needs_revision');
+  });
+
+  test('recognizes canonical approved marker', () => {
+    const output = '# Critic Report\n\n<!-- signal: approved -->';
+    expect(parseSignals('critic', 'planning', output)).toBe('approved');
+  });
+
+  test('canonical marker overrides conflicting natural-language verdict', () => {
+    const output = '## Verdict: READY\n\n<!-- signal: needs_revision -->';
+    expect(parseSignals('critic', 'planning', output)).toBe('needs_revision');
+  });
+
+  test('canonical marker is case-insensitive on the comment, signal name normalized', () => {
+    const output = '<!-- SIGNAL: Needs_Revision -->';
+    expect(parseSignals('critic', 'planning', output)).toBe('needs_revision');
+  });
+
+  test('tolerates extra whitespace inside the marker', () => {
+    const output = '<!--   signal:    approved   -->';
+    expect(parseSignals('review', 'planning', output)).toBe('approved');
+  });
+
+  test('falls back to natural-language matching when marker missing', () => {
+    const output = '## Verdict: NEEDS REVISION\n\nIssues identified.';
+    expect(parseSignals('critic', 'planning', output)).toBe('needs_revision');
+  });
+
+  test('ignores unknown signal names in the marker and falls back', () => {
+    const output = '<!-- signal: bogus_signal -->\n\n## Verdict: NEEDS REVISION';
+    expect(parseSignals('critic', 'planning', output)).toBe('needs_revision');
+  });
+});

--- a/src/modules/workflow/runtime/signals.ts
+++ b/src/modules/workflow/runtime/signals.ts
@@ -4,9 +4,17 @@
  * Extracts structured condition signals (needs_revision, has_open_questions)
  * from agent output text. Used by WorkflowContext.dispatch() to populate
  * StepResult.signal.
+ *
+ * Agents should emit a canonical HTML-comment marker like
+ * `<!-- signal: needs_revision -->` so the runtime is not coupled to the
+ * agent's prose. Natural-language verdict headings remain a best-effort
+ * fallback for legacy outputs.
  */
 
 type SignalMatcher = (content: string) => boolean;
+
+/** Canonical signal marker — invisible in rendered markdown, unambiguous to parse. */
+const CANONICAL_MARKER_PATTERN = /<!--\s*signal:\s*([a-z_]+)\s*-->/i;
 
 const CONDITION_PATTERNS: Record<string, SignalMatcher> = {
   // Planning critic signals — matches heading, inline, and bold markdown variants
@@ -50,7 +58,12 @@ const CONDITION_PATTERNS: Record<string, SignalMatcher> = {
 
 /**
  * Parse condition signals from agent output text.
- * Returns the first matching signal name, or null if no patterns match.
+ *
+ * Resolution order:
+ *   1. Canonical `<!-- signal: <name> -->` marker (authoritative — agent's stated intent).
+ *   2. Natural-language verdict headings / bold markers via CONDITION_PATTERNS.
+ *
+ * Returns the resolved signal name, or null if nothing matches.
  */
 export function parseSignals(
   _stepId: string,
@@ -58,6 +71,12 @@ export function parseSignals(
   output: string | undefined
 ): string | null {
   if (!output) return null;
+
+  const markerMatch = output.match(CANONICAL_MARKER_PATTERN);
+  if (markerMatch) {
+    const signal = markerMatch[1].toLowerCase();
+    if (signal in CONDITION_PATTERNS) return signal;
+  }
 
   for (const [signal, matcher] of Object.entries(CONDITION_PATTERNS)) {
     if (matcher(output)) return signal;

--- a/src/modules/workflow/templates/planning-critic.md
+++ b/src/modules/workflow/templates/planning-critic.md
@@ -114,7 +114,18 @@ Write your findings to `.plans/{{PLAN_ID}}/critic-report.md` with this structure
 Total: <N> FIX items
 1. <file/section> — <brief description>
 2. ...
+
+<!-- signal: needs_revision -->
 ```
+
+### Signal Marker (REQUIRED)
+
+The last line of your report MUST be a canonical signal marker so the workflow runtime can route reliably:
+
+- `<!-- signal: needs_revision -->` — design has FIX items that must be addressed before implementation.
+- `<!-- signal: approved -->` — design is READY; no FIX items remain.
+
+The marker is invisible in rendered markdown but is parsed verbatim by the runtime. Pick exactly one — it must agree with your stated `## Verdict:`. Do not omit it; without the marker, the auto-revision loop cannot fire and a flawed design may advance to implementation.
 
 ## Important
 


### PR DESCRIPTION
## Summary

- Adds canonical HTML-comment signal marker (`<!-- signal: needs_revision -->`) recognized by parseSignals
- Falls back to natural-language `## Verdict: NEEDS REVISION` heading
- Updates planning-critic.md template to emit the marker

## Why

Closes VNM-48.277. The planning workflow's auto-revision loop never fired when critics correctly identified issues — parseSignals didn't recognize the verdict heading the agent already produced. Repro: planning instance 622c5d67 advanced to spec-tests on a flawed design because critic.signal stayed null. With this fix, the loop self-iterates up to 3 times when the critic returns NEEDS REVISION.

Composes with VNM-48.276 (assisted step content) and VNM-48.278 (revise action) to close the planning revision loop end-to-end.

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npx eslint` passes
- [ ] signals.test.ts covers marker + heading + neither + both-marker-wins cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)