### PR TITLE
Inject dependency PR context into AI review prompts (VNM-56.42)

### DIFF
--- a/__tests__/modules/agents/delivery-review.test.ts
+++ b/__tests__/modules/agents/delivery-review.test.ts
@@ -6,6 +6,7 @@ import {
   parseRiskScore,
   runHumanReviewGate,
   resolveOriginalSessionId,
+  buildReviewPrompt,
   type ReviewDeps,
   type ReviewRunOutput,
 } from '../../../src/modules/agents/delivery-review.js';
@@ -729,6 +730,73 @@ describe('resolveOriginalSessionId', () => {
     // No tables — function should swallow the error and return null.
     const result = resolveOriginalSessionId(db, makeDelivery());
     expect(result).toBeNull();
+    db.close();
+  });
+});
+
+// ── buildReviewPrompt — dependency context injection ────────────────────────
+
+describe('buildReviewPrompt dependency context', () => {
+  function makeDbWithDeps(): Database.Database {
+    const db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE notes (
+        id TEXT PRIMARY KEY,
+        title TEXT,
+        type TEXT,
+        module TEXT,
+        metadata TEXT,
+        content_dir TEXT
+      );
+      CREATE TABLE delivery_states (
+        agent_id TEXT PRIMARY KEY,
+        task_id TEXT NOT NULL,
+        branch TEXT,
+        status TEXT,
+        pr_number INTEGER,
+        pr_url TEXT,
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `);
+    return db;
+  }
+
+  it('includes upstream PR/branch info in the fallback prompt when deps exist', () => {
+    const db = makeDbWithDeps();
+    db.prepare(
+      `INSERT INTO notes (id, title, type, module, metadata)
+       VALUES ('dep', 'Add fix_attempts column', 'task', 'pm', ?)`
+    ).run(JSON.stringify({ display_id: 'VNM-56.24', status: 'done', depends_on: [] }));
+    db.prepare(
+      `INSERT INTO delivery_states (agent_id, task_id, branch, status, pr_number, pr_url)
+       VALUES ('a-dep', 'VNM-56.24', 'agent/VNM-56/VNM-56.24', 'merged', 142,
+               'https://github.com/example/repo/pull/142')`
+    ).run();
+    db.prepare(
+      `INSERT INTO notes (id, title, type, module, metadata)
+       VALUES ('cur', 'Use column', 'task', 'pm', ?)`
+    ).run(
+      JSON.stringify({ display_id: 'VNM-56.42', status: 'pending', depends_on: ['VNM-56.24'] })
+    );
+
+    const delivery = { ...makeDelivery(), task_id: 'VNM-56.42' };
+    const prompt = buildReviewPrompt(db, delivery, '/tmp/project');
+    expect(prompt).toContain('## Dependency PR Context');
+    expect(prompt).toContain('VNM-56.24');
+    expect(prompt).toContain('agent/VNM-56/VNM-56.24');
+    expect(prompt).toContain('https://github.com/example/repo/pull/142');
+    db.close();
+  });
+
+  it('omits the dependency block when the task has no upstream deps', () => {
+    const db = makeDbWithDeps();
+    db.prepare(
+      `INSERT INTO notes (id, title, type, module, metadata)
+       VALUES ('cur', 'Solo', 'task', 'pm', ?)`
+    ).run(JSON.stringify({ display_id: 'VNM-56.29', status: 'pending', depends_on: [] }));
+
+    const prompt = buildReviewPrompt(db, makeDelivery(), '/tmp/project');
+    expect(prompt).not.toContain('## Dependency PR Context');
     db.close();
   });
 });

--- a/__tests__/modules/pm/engine/review-context.test.ts
+++ b/__tests__/modules/pm/engine/review-context.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  buildDependencyPRContexts,
+  buildDependencyContextString,
+  renderDependencyContextBlock,
+  type DependencyPRContext,
+} from '../../../../src/modules/pm/engine/review-context.js';
+
+function createNotesSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE notes (
+      id TEXT PRIMARY KEY,
+      file_path TEXT,
+      title TEXT,
+      type TEXT,
+      module TEXT,
+      module_instance TEXT,
+      metadata TEXT,
+      content_dir TEXT
+    );
+    CREATE TABLE delivery_states (
+      agent_id TEXT PRIMARY KEY,
+      task_id TEXT NOT NULL,
+      branch TEXT,
+      status TEXT,
+      pr_number INTEGER,
+      pr_url TEXT,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+}
+
+function insertTask(
+  db: Database.Database,
+  opts: {
+    id: string;
+    title: string;
+    displayId: string;
+    status?: string;
+    dependsOn?: string[];
+    contentDir?: string | null;
+  }
+): void {
+  db.prepare(
+    `INSERT INTO notes (id, title, type, module, metadata, content_dir)
+     VALUES (?, ?, 'task', 'pm', ?, ?)`
+  ).run(
+    opts.id,
+    opts.title,
+    JSON.stringify({
+      display_id: opts.displayId,
+      status: opts.status ?? 'pending',
+      depends_on: opts.dependsOn ?? [],
+    }),
+    opts.contentDir ?? null
+  );
+}
+
+function insertDelivery(
+  db: Database.Database,
+  opts: {
+    agentId: string;
+    taskId: string;
+    branch?: string | null;
+    prNumber?: number | null;
+    prUrl?: string | null;
+    updatedAt?: string;
+  }
+): void {
+  db.prepare(
+    `INSERT INTO delivery_states (agent_id, task_id, branch, status, pr_number, pr_url, updated_at)
+     VALUES (?, ?, ?, 'pr-open', ?, ?, ?)`
+  ).run(
+    opts.agentId,
+    opts.taskId,
+    opts.branch ?? null,
+    opts.prNumber ?? null,
+    opts.prUrl ?? null,
+    opts.updatedAt ?? new Date().toISOString()
+  );
+}
+
+describe('buildDependencyPRContexts', () => {
+  let db: Database.Database;
+  let workDir: string;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createNotesSchema(db);
+    workDir = mkdtempSync(join(tmpdir(), 'review-context-'));
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it('returns [] when the task has no recorded dependencies', () => {
+    insertTask(db, { id: 'n1', title: 'Solo', displayId: 'VNM-56.42', dependsOn: [] });
+    expect(buildDependencyPRContexts(db, 'VNM-56.42')).toEqual([]);
+  });
+
+  it('returns [] when the task does not exist', () => {
+    expect(buildDependencyPRContexts(db, 'VNM-56.99')).toEqual([]);
+  });
+
+  it('returns one entry per upstream task with title, status, branch, and PR url', () => {
+    insertTask(db, { id: 'dep1', title: 'Add fix_attempts column', displayId: 'VNM-56.24' });
+    insertDelivery(db, {
+      agentId: 'a1',
+      taskId: 'VNM-56.24',
+      branch: 'agent/VNM-56/VNM-56.24',
+      prNumber: 142,
+      prUrl: 'https://github.com/example/repo/pull/142',
+    });
+    insertTask(db, {
+      id: 'cur',
+      title: 'Use fix_attempts',
+      displayId: 'VNM-56.42',
+      dependsOn: ['VNM-56.24'],
+    });
+
+    const result = buildDependencyPRContexts(db, 'VNM-56.42');
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      displayId: 'VNM-56.24',
+      title: 'Add fix_attempts column',
+      branch: 'agent/VNM-56/VNM-56.24',
+      prNumber: 142,
+      prUrl: 'https://github.com/example/repo/pull/142',
+    });
+  });
+
+  it('includes the upstream summary.md when present and trims it', () => {
+    const depDir = join(workDir, 'dep');
+    mkdirSync(depDir, { recursive: true });
+    const summary = 'Adds the fix_attempts column to delivery_states.\nMigration v4.';
+    writeFileSync(join(depDir, 'summary.md'), summary);
+
+    insertTask(db, {
+      id: 'dep1',
+      title: 'Migration',
+      displayId: 'VNM-56.24',
+      contentDir: depDir,
+    });
+    insertTask(db, {
+      id: 'cur',
+      title: 'Consumer',
+      displayId: 'VNM-56.42',
+      dependsOn: ['VNM-56.24'],
+    });
+
+    const result = buildDependencyPRContexts(db, 'VNM-56.42');
+    expect(result[0].summary).toBe(summary);
+  });
+
+  it('still records the dependency display_id when the upstream task is not yet ingested', () => {
+    insertTask(db, {
+      id: 'cur',
+      title: 'Consumer',
+      displayId: 'VNM-56.42',
+      dependsOn: ['VNM-99.01'],
+    });
+
+    const result = buildDependencyPRContexts(db, 'VNM-56.42');
+    expect(result).toEqual<DependencyPRContext[]>([
+      {
+        displayId: 'VNM-99.01',
+        title: 'VNM-99.01',
+        status: 'unknown',
+        branch: null,
+        prNumber: null,
+        prUrl: null,
+        summary: null,
+      },
+    ]);
+  });
+
+  it('preserves order of depends_on and uses the most recent delivery_state row', () => {
+    insertTask(db, { id: 'd1', title: 'Dep One', displayId: 'VNM-56.24' });
+    insertTask(db, { id: 'd2', title: 'Dep Two', displayId: 'VNM-56.27' });
+    insertDelivery(db, {
+      agentId: 'old',
+      taskId: 'VNM-56.24',
+      branch: 'old-branch',
+      updatedAt: '2026-01-01T00:00:00Z',
+    });
+    insertDelivery(db, {
+      agentId: 'new',
+      taskId: 'VNM-56.24',
+      branch: 'new-branch',
+      prNumber: 200,
+      updatedAt: '2026-04-01T00:00:00Z',
+    });
+    insertTask(db, {
+      id: 'cur',
+      title: 'Consumer',
+      displayId: 'VNM-56.42',
+      dependsOn: ['VNM-56.27', 'VNM-56.24'],
+    });
+
+    const result = buildDependencyPRContexts(db, 'VNM-56.42');
+    expect(result.map((r) => r.displayId)).toEqual(['VNM-56.27', 'VNM-56.24']);
+    expect(result[1].branch).toBe('new-branch');
+    expect(result[1].prNumber).toBe(200);
+  });
+});
+
+describe('renderDependencyContextBlock', () => {
+  it('returns an empty string when there are no contexts', () => {
+    expect(renderDependencyContextBlock([])).toBe('');
+  });
+
+  it('renders headings, status, branch, PR, and summary', () => {
+    const block = renderDependencyContextBlock([
+      {
+        displayId: 'VNM-56.24',
+        title: 'Add fix_attempts column',
+        status: 'done',
+        branch: 'agent/VNM-56/VNM-56.24',
+        prNumber: 142,
+        prUrl: 'https://github.com/example/repo/pull/142',
+        summary: 'Adds the column.',
+      },
+    ]);
+
+    expect(block).toContain('## Dependency PR Context');
+    expect(block).toContain('### VNM-56.24 — Add fix_attempts column');
+    expect(block).toContain('Status: done');
+    expect(block).toContain('PR: https://github.com/example/repo/pull/142 (#142)');
+    expect(block).toContain('Branch: `agent/VNM-56/VNM-56.24`');
+    expect(block).toContain('Summary from upstream author:');
+    expect(block).toContain('Adds the column.');
+    expect(block.trimEnd().endsWith('---')).toBe(true);
+  });
+});
+
+describe('buildDependencyContextString', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createNotesSchema(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('returns "" when taskDisplayId is null/undefined', () => {
+    expect(buildDependencyContextString(db, null)).toBe('');
+    expect(buildDependencyContextString(db, undefined)).toBe('');
+    expect(buildDependencyContextString(db, '')).toBe('');
+  });
+
+  it('returns "" when no dependencies exist', () => {
+    insertTask(db, { id: 'n1', title: 'Solo', displayId: 'VNM-56.42' });
+    expect(buildDependencyContextString(db, 'VNM-56.42')).toBe('');
+  });
+
+  it('returns rendered block when dependencies exist', () => {
+    insertTask(db, { id: 'd1', title: 'Up', displayId: 'VNM-56.24' });
+    insertTask(db, {
+      id: 'cur',
+      title: 'Consumer',
+      displayId: 'VNM-56.42',
+      dependsOn: ['VNM-56.24'],
+    });
+    const block = buildDependencyContextString(db, 'VNM-56.42');
+    expect(block).toContain('## Dependency PR Context');
+    expect(block).toContain('VNM-56.24');
+  });
+
+  it('does not throw when delivery_states table is missing', () => {
+    const bareDb = new Database(':memory:');
+    bareDb.exec(`
+      CREATE TABLE notes (
+        id TEXT PRIMARY KEY,
+        title TEXT,
+        type TEXT,
+        module TEXT,
+        metadata TEXT,
+        content_dir TEXT
+      );
+    `);
+    bareDb
+      .prepare(
+        `INSERT INTO notes (id, title, type, module, metadata)
+         VALUES ('d', 'Up', 'task', 'pm', ?)`
+      )
+      .run(JSON.stringify({ display_id: 'VNM-56.24', status: 'done', depends_on: [] }));
+    bareDb
+      .prepare(
+        `INSERT INTO notes (id, title, type, module, metadata)
+         VALUES ('c', 'Consumer', 'task', 'pm', ?)`
+      )
+      .run(
+        JSON.stringify({
+          display_id: 'VNM-56.42',
+          status: 'pending',
+          depends_on: ['VNM-56.24'],
+        })
+      );
+
+    expect(() => buildDependencyContextString(bareDb, 'VNM-56.42')).not.toThrow();
+    bareDb.close();
+  });
+});

--- a/src/modules/agents/delivery-review.ts
+++ b/src/modules/agents/delivery-review.ts
@@ -8,6 +8,7 @@ import type { DeliveryRecord } from './delivery.js';
 import { recordDelivery, readAndClearHumanSignal } from './delivery.js';
 import { parseSignals } from '../workflow/runtime/signals.js';
 import { renderTemplate } from '../workflow/engine/templates.js';
+import { buildDependencyContextString } from '../pm/engine/review-context.js';
 import { sleep } from '../../utils/db.js';
 
 export type ReviewTier = 'ci-only' | 'ai-review' | 'human-review';
@@ -390,7 +391,7 @@ async function runReviewAgent(
   delivery: DeliveryRecord,
   projectDir: string
 ): Promise<ReviewRunOutput> {
-  const prompt = buildReviewPrompt(delivery, projectDir);
+  const prompt = buildReviewPrompt(db, delivery, projectDir);
   const result = await spawnClaudeReview(prompt, projectDir, RESEARCH_TOOLS);
   persistReviewAgentId(db, delivery.agent_id, result.agentId);
   return result;
@@ -426,9 +427,14 @@ export function resolveOriginalSessionId(
   }
 }
 
-function buildReviewPrompt(delivery: DeliveryRecord, projectDir: string): string {
+export function buildReviewPrompt(
+  db: Database.Database,
+  delivery: DeliveryRecord,
+  projectDir: string
+): string {
   const repo = getRepoInfo(projectDir);
   const prefix = delivery.task_id ? delivery.task_id.split('.')[0] : 'VNM';
+  const dependencyContext = buildDependencyContextString(db, delivery.task_id);
   const vars: Record<string, string> = {
     OWNER: repo.owner,
     REPO: repo.repo,
@@ -438,9 +444,11 @@ function buildReviewPrompt(delivery: DeliveryRecord, projectDir: string): string
     REPO_PATH: projectDir,
     PROJECT_PREFIX: prefix,
     REVIEW_THRESHOLD: '4',
+    DEPENDENCY_CONTEXT: dependencyContext,
   };
   const rendered = renderTemplate('review-agent', vars);
-  return rendered.ok ? rendered.data : fallbackReviewPrompt(delivery, projectDir, repo);
+  if (rendered.ok) return rendered.data;
+  return fallbackReviewPrompt(delivery, projectDir, repo, dependencyContext);
 }
 
 function buildFixupPrompt(
@@ -488,16 +496,22 @@ function prependReviewFindings(base: string, summary: ReviewSummary): string {
 function fallbackReviewPrompt(
   delivery: DeliveryRecord,
   projectDir: string,
-  repo: { owner: string; repo: string }
+  repo: { owner: string; repo: string },
+  dependencyContext: string
 ): string {
-  return [
-    `Review PR #${delivery.pr_number ?? '?'} in ${repo.owner}/${repo.repo}.`,
-    `Branch: ${delivery.branch ?? ''} targeting main`,
-    `Repo path: ${projectDir}`,
-    '',
-    'Read the diff, evaluate code quality, and post a GitHub review.',
-    'Output Verdict: PASS or NEEDS WORK, and Risk: <1-5> in an orchestrator summary.',
-  ].join('\n');
+  const parts: string[] = [];
+  if (dependencyContext) parts.push(dependencyContext);
+  parts.push(
+    [
+      `Review PR #${delivery.pr_number ?? '?'} in ${repo.owner}/${repo.repo}.`,
+      `Branch: ${delivery.branch ?? ''} targeting main`,
+      `Repo path: ${projectDir}`,
+      '',
+      'Read the diff, evaluate code quality, and post a GitHub review.',
+      'Output Verdict: PASS or NEEDS WORK, and Risk: <1-5> in an orchestrator summary.',
+    ].join('\n')
+  );
+  return parts.join('\n');
 }
 
 function fallbackFixupPrompt(delivery: DeliveryRecord, reviewOutput: string): string {

--- a/src/modules/pm/engine/review-context.ts
+++ b/src/modules/pm/engine/review-context.ts
@@ -1,0 +1,192 @@
+import type Database from 'better-sqlite3';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface DependencyPRContext {
+  displayId: string;
+  title: string;
+  status: string;
+  branch: string | null;
+  prNumber: number | null;
+  prUrl: string | null;
+  summary: string | null;
+}
+
+interface TaskRow {
+  id: string;
+  title: string | null;
+  metadata: string | null;
+  contentDir: string | null;
+}
+
+interface DeliveryRow {
+  branch: string | null;
+  pr_number: number | null;
+  pr_url: string | null;
+}
+
+const SUMMARY_MAX_CHARS = 1200;
+
+function findTaskByDisplayId(db: Database.Database, displayId: string): TaskRow | null {
+  try {
+    const row = db
+      .prepare(
+        `SELECT id, title, metadata, content_dir as contentDir
+         FROM notes
+         WHERE module = 'pm'
+           AND type = 'task'
+           AND json_extract(metadata, '$.display_id') = ?
+         LIMIT 1`
+      )
+      .get(displayId) as TaskRow | undefined;
+    return row ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function readDependsOn(metadata: string | null): string[] {
+  if (!metadata) return [];
+  try {
+    const meta = JSON.parse(metadata) as { depends_on?: string[] };
+    return Array.isArray(meta.depends_on) ? meta.depends_on : [];
+  } catch {
+    return [];
+  }
+}
+
+function readTaskStatus(metadata: string | null): string {
+  if (!metadata) return 'unknown';
+  try {
+    const meta = JSON.parse(metadata) as { status?: string };
+    return meta.status ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+function readTaskSummary(contentDir: string | null): string | null {
+  if (!contentDir) return null;
+  const summaryPath = join(contentDir, 'summary.md');
+  if (!existsSync(summaryPath)) return null;
+  const text = readFileSync(summaryPath, 'utf-8').trim();
+  if (!text) return null;
+  return text.length > SUMMARY_MAX_CHARS
+    ? text.slice(0, SUMMARY_MAX_CHARS).trimEnd() + '\n…'
+    : text;
+}
+
+function findLatestDelivery(db: Database.Database, taskId: string): DeliveryRow | null {
+  try {
+    const row = db
+      .prepare(
+        `SELECT branch, pr_number, pr_url
+         FROM delivery_states
+         WHERE task_id = ?
+         ORDER BY updated_at DESC
+         LIMIT 1`
+      )
+      .get(taskId) as DeliveryRow | undefined;
+    return row ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build dependency context for an AI reviewer evaluating a PR.
+ *
+ * Returns one entry per upstream task referenced in the task's `depends_on`.
+ * Each entry includes the dependency's title, status, agent branch, PR URL,
+ * and (when available) the summary the dependency author wrote at completion.
+ *
+ * Reviewers see each PR in isolation, so missing schemas/columns/functions
+ * declared by an unmerged dependency get flagged as critical issues. Passing
+ * this context into the review prompt lets the reviewer recognize that what
+ * looks like a missing reference is actually provided by an upstream PR.
+ */
+export function buildDependencyPRContexts(
+  db: Database.Database,
+  taskDisplayId: string
+): DependencyPRContext[] {
+  const task = findTaskByDisplayId(db, taskDisplayId);
+  if (!task) return [];
+  const dependsOn = readDependsOn(task.metadata);
+  if (dependsOn.length === 0) return [];
+
+  const contexts: DependencyPRContext[] = [];
+  for (const depId of dependsOn) {
+    const depTask = findTaskByDisplayId(db, depId);
+    if (!depTask) {
+      contexts.push({
+        displayId: depId,
+        title: depId,
+        status: 'unknown',
+        branch: null,
+        prNumber: null,
+        prUrl: null,
+        summary: null,
+      });
+      continue;
+    }
+    const delivery = findLatestDelivery(db, depId);
+    contexts.push({
+      displayId: depId,
+      title: depTask.title ?? depId,
+      status: readTaskStatus(depTask.metadata),
+      branch: delivery?.branch ?? null,
+      prNumber: delivery?.pr_number ?? null,
+      prUrl: delivery?.pr_url ?? null,
+      summary: readTaskSummary(depTask.contentDir),
+    });
+  }
+  return contexts;
+}
+
+/**
+ * Render dependency contexts as a markdown block ready to inject into a
+ * review-agent prompt. Returns an empty string when there are no
+ * dependencies, so the template falls back to its base text without an
+ * empty section.
+ */
+export function renderDependencyContextBlock(contexts: DependencyPRContext[]): string {
+  if (contexts.length === 0) return '';
+  const lines: string[] = [
+    '## Dependency PR Context',
+    '',
+    'This PR depends on the following upstream task(s). Their PRs may not yet',
+    'be merged into the base branch you are diffing against. Schema, columns,',
+    'functions, types, or files referenced by the current PR but missing from',
+    'the diff are likely provided by these dependencies — do NOT flag them as',
+    'critical issues without first checking the upstream branches/PRs.',
+    '',
+  ];
+  for (const ctx of contexts) {
+    lines.push(`### ${ctx.displayId} — ${ctx.title}`);
+    lines.push(`- Status: ${ctx.status}`);
+    if (ctx.prUrl) {
+      lines.push(`- PR: ${ctx.prUrl}${ctx.prNumber ? ` (#${ctx.prNumber})` : ''}`);
+    } else if (ctx.prNumber) {
+      lines.push(`- PR: #${ctx.prNumber}`);
+    }
+    if (ctx.branch) lines.push(`- Branch: \`${ctx.branch}\``);
+    if (ctx.summary) {
+      lines.push('');
+      lines.push('Summary from upstream author:');
+      lines.push('');
+      lines.push(ctx.summary);
+    }
+    lines.push('');
+  }
+  lines.push('---');
+  lines.push('');
+  return lines.join('\n');
+}
+
+export function buildDependencyContextString(
+  db: Database.Database,
+  taskDisplayId: string | null | undefined
+): string {
+  if (!taskDisplayId) return '';
+  return renderDependencyContextBlock(buildDependencyPRContexts(db, taskDisplayId));
+}

--- a/src/modules/workflow/templates/review-agent.md
+++ b/src/modules/workflow/templates/review-agent.md
@@ -16,16 +16,24 @@ Blank-slate code review for a GitHub PR. Fill in variables and pass as agent pro
 | `{{REPO_PATH}}` | Absolute path to repo on disk | `/Users/hjewkes/Documents/projects/voltras-workspace/voltras/mobile` |
 | `{{PROJECT_PREFIX}}` | Project key from project-map.json | `VLT` |
 | `{{REVIEW_THRESHOLD}}` | Risk score that triggers human review | `4` |
+| `{{DEPENDENCY_CONTEXT}}` | Markdown block describing upstream PRs this one depends on (empty when none) | `## Dependency PR Context\n…` |
 
 ---
 
 ## Agent Prompt
 
+{{DEPENDENCY_CONTEXT}}
 You are reviewing PR #{{PR_NUMBER}} in {{OWNER}}/{{REPO}}.
 
 Branch: `{{BRANCH}}` targeting `{{BASE}}`
 Repo path: `{{REPO_PATH}}`
 Project: `{{PROJECT_PREFIX}}` | Human review threshold: `{{REVIEW_THRESHOLD}}`
+
+If a `## Dependency PR Context` block is shown above, read it first. References to
+schemas, columns, functions, types, or files declared by an upstream task should
+NOT be flagged as missing/critical without first inspecting that dependency's
+branch — the PR you are reviewing was authored against an integrated base where
+those upstream changes already exist.
 
 ### Step 1: Read the full diff
 


### PR DESCRIPTION
## Summary

- Adds review-context.ts that pulls dependency PRs from `depends_on` + agent completion summaries
- Injects context into the AI reviewer prompt so it knows what upstream PRs provide
- Reviewer instructed not to flag items provided by deps as critical

## Why

Closes VNM-56.42. AI reviewers were flagging missing schemas/columns/functions as critical when a dep PR provided them — 4 of 7 critical findings on VNM-56 were false positives caused by missing dependency context.

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npx eslint` passes
- [ ] review-context.test.ts covers extraction from PM deps + agent summaries
- [ ] delivery-review.test.ts updated for new context wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)