### PR TITLE
Move plan-dir cleanup into seed step to survive hydration (VNM-48.279)

### DIFF
--- a/__tests__/modules/workflow/flows/planning.test.ts
+++ b/__tests__/modules/workflow/flows/planning.test.ts
@@ -31,7 +31,7 @@ class TestableContext implements WorkflowContextInterface {
   readonly runId = `test-${randomUUID().slice(0, 8)}`;
   readonly workflowName = 'planning';
   readonly project = 'TST';
-  readonly projectDir = '/tmp/test';
+  readonly projectDir: string;
 
   calls: DispatchCall[] = [];
 
@@ -40,8 +40,9 @@ class TestableContext implements WorkflowContextInterface {
   private signalMap = new Map<SignalKey, string | null>();
   private cachedResults: Record<string, StepResult> = {};
 
-  constructor(params: Record<string, string> = {}) {
+  constructor(params: Record<string, string> = {}, projectDir = '/tmp/test') {
     this.params = { brief: 'Test planning workflow', ...params };
+    this.projectDir = projectDir;
   }
 
   /** Pre-configure what signal a step returns at a given iteration index. */
@@ -340,6 +341,62 @@ describe('planningWorkflow — flow logic', () => {
       'review',
       'decompose',
     ]);
+  });
+
+  test('hydration preserves plan-dir artifacts when seed is cached (VNM-48.279)', async () => {
+    const tmp = join(tmpdir(), `planning-hydration-${randomUUID()}`);
+    const planId = 'plan-hydrate';
+    const planDir = join(tmp, '.plans', planId);
+    const designFile = join(planDir, 'design.md');
+
+    try {
+      // Simulate a prior run that produced a design artifact
+      mkdirSync(planDir, { recursive: true });
+      const { writeFileSync } = await import('node:fs');
+      writeFileSync(designFile, '# Prior design output');
+
+      const ctx = new TestableContext({ complexity: 'low', planId }, tmp);
+
+      // Cache seed step — this simulates hydration after a brain restart
+      ctx.setCachedAssisted('seed', {
+        stepId: 'seed',
+        taskId: 'seed:seed',
+        agentId: null,
+        signal: null,
+        completedAt: '2026-01-01T00:00:00Z',
+      });
+
+      await planningWorkflow(ctx);
+
+      // The cached seed must NOT fire the rmSync — prior artifacts preserved
+      expect(existsSync(designFile)).toBe(true);
+    } finally {
+      if (existsSync(tmp)) rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('first run cleans pre-existing plan-dir artifacts via seed step', async () => {
+    const tmp = join(tmpdir(), `planning-firstrun-${randomUUID()}`);
+    const planId = 'plan-firstrun';
+    const planDir = join(tmp, '.plans', planId);
+    const stalePath = join(planDir, 'stale-from-prior-run.md');
+
+    try {
+      mkdirSync(planDir, { recursive: true });
+      const { writeFileSync } = await import('node:fs');
+      writeFileSync(stalePath, '# stale');
+
+      // No cached seed — this is a fresh workflow instance
+      const ctx = new TestableContext({ complexity: 'low', planId }, tmp);
+
+      await planningWorkflow(ctx);
+
+      // Seed ran, rmSync fired, stale artifact gone, fresh dir + context.md present
+      expect(existsSync(stalePath)).toBe(false);
+      expect(existsSync(join(planDir, 'pre-existing-context.md'))).toBe(true);
+    } finally {
+      if (existsSync(tmp)) rmSync(tmp, { recursive: true, force: true });
+    }
   });
 
   test('restart recovery: memoized steps skip on re-invocation', async () => {

--- a/src/modules/workflow/flows/planning-seed.ts
+++ b/src/modules/workflow/flows/planning-seed.ts
@@ -4,7 +4,7 @@
  * answers) before the LLM-driven planning pipeline begins.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type { SeedResult } from '../runtime/types.js';
 
@@ -163,8 +163,14 @@ export function buildPlanningSeed(params: SeedParams): () => Promise<SeedResult>
     const flags = assessCoverage(sections, params);
     const skipResearch = shouldSkipResearch(flags);
 
-    // Write the gathered context to disk
+    // Clean prior run artifacts then recreate the plan directory.
+    // This is intentionally inside the seed function (which is cached after
+    // first run) rather than at workflow-function top level — otherwise
+    // hydration replays would destroy artifacts from later steps.
     const planDir = resolve(params.projectDir, '.plans', params.planId);
+    if (existsSync(planDir)) {
+      rmSync(planDir, { recursive: true, force: true });
+    }
     mkdirSync(planDir, { recursive: true });
     const contextPath = resolve(planDir, 'pre-existing-context.md');
 

--- a/src/modules/workflow/flows/planning.ts
+++ b/src/modules/workflow/flows/planning.ts
@@ -22,8 +22,6 @@
  *   interviewAnswers: pre-filled interview responses
  */
 
-import { existsSync, rmSync, mkdirSync } from 'node:fs';
-import { resolve } from 'node:path';
 import type { WorkflowFn } from '../runtime/types.js';
 import { buildPlanningSeed } from './planning-seed.js';
 import { buildPlanningCompletion } from './planning-completion.js';
@@ -41,14 +39,10 @@ export const planningWorkflow: WorkflowFn = async (ctx) => {
   const explicitSkipResearch = ctx.param('skipResearch') === 'true';
   const planId = ctx.param('planId') ?? ctx.runId.slice(0, 8);
 
-  // Clean plan directory to prevent prior run artifacts from polluting this run
-  const planDir = resolve(ctx.projectDir, '.plans', planId);
-  if (existsSync(planDir)) {
-    rmSync(planDir, { recursive: true, force: true });
-  }
-  mkdirSync(planDir, { recursive: true });
-
-  // Seed phase — gather pre-existing context (deterministic, no LLM)
+  // Seed phase — gather pre-existing context (deterministic, no LLM).
+  // Plan-dir cleanup happens INSIDE the seed step so it's cached as a unit
+  // and won't fire on hydration replay (which would otherwise destroy
+  // artifacts from prior steps in the same workflow instance).
   const priorContext = ctx.param('priorContext') ?? brief;
   await ctx.seed(
     'seed',


### PR DESCRIPTION
## Summary

- Moves \`rmSync(planDir)\` + \`mkdirSync(planDir)\` from the planning workflow function body **into** \`buildPlanningSeed\`, where it's cached as part of the seed step
- Adds two regression tests: hydration preserves artifacts when seed is cached; first run still cleans stale artifacts

## Why

Closes **VNM-48.279** (critical). Confirmed live this session: brain restart silently destroyed all paused/completed planning workflow artifacts because the cleanup ran on every workflow function invocation, including hydration replays.

## Mechanics

- **Before:** rmSync + mkdirSync executed at line 44–49 of \`planning.ts\`, outside any step. Every hydration replayed the function body and fired the rmSync.
- **After:** cleanup lives inside \`buildPlanningSeed\` (the function passed to \`ctx.seed\`). On first run: seed fires → rmSync cleans → mkdirSync creates. On hydration: seed is cached, \`fn()\` isn't called, prior artifacts preserved.

This matches the documented invariant the task captured: workflow function bodies should be pure orchestration; side-effects belong inside steps.

## Audit

Grepped all of \`src/modules/workflow/flows/\` for similar unconditional fs side-effects. Only \`planning.ts:44–49\` had the bug. \`planning-completion.ts:146\` looked similar but is inside \`cleanupPlanDir\` which is called from a step. Other flows (implementation, review, brainstorming, pr-lifecycle, ux-prototype, single-step, wave-execution) have no module-level fs writes.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] \`npx eslint\` clean
- [x] All 27 planning.test.ts tests pass, including 2 new regression tests
- [ ] Integration: brain restart with paused planning workflow → artifacts remain on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)