### PR TITLE
Add user-facing quickstart docs for 6 undocumented subsystems (VNM-22.09)

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,11 +271,22 @@ npx tsx src/cli.ts # Run CLI in development
 
 ## Documentation
 
+### Project Management
+
 - [PM Quick Start](docs/pm-module/quickstart.md)
 - [PM User Guide](docs/pm-module/guide.md)
 - [PM Architecture](docs/pm-module/architecture.md)
 - [PM Command Reference](docs/pm-module/commands.md)
 - [Demo Workflow](docs/pm-module/demo.md)
+
+### Subsystems
+
+- [Workflow Runtime](docs/workflow/quickstart.md) — V2 imperative workflows with memoized dispatch and agent supervision
+- [MCP Server](docs/mcp/quickstart.md) — MCP tool catalog, stdio/HTTP transports, example sessions
+- [Hook Dispatch](docs/hooks/quickstart.md) — Ownership, git-safety, WIP limits, DoD checks, configuration
+- [Agent Module](docs/agents/quickstart.md) — Agent lifecycle, worktree allocation, done-handler
+- [Session Intelligence](docs/sessions/quickstart.md) — Session ingestion, analytics, briefings, restore flow
+- [Codebase Indexing](docs/codebase/quickstart.md) — Architecture scanning, post-merge hook setup
 
 ## License
 

--- a/docs/agents/quickstart.md
+++ b/docs/agents/quickstart.md
@@ -1,0 +1,129 @@
+# Agent Module Quick Start
+
+The agent module tracks Claude agent instances throughout their lifecycle — from registration through completion. Each agent gets a unique ID, an isolated git worktree, file ownership claims, and a PM task association. The done-handler hook automatically updates PM state and captures artifacts when an agent exits.
+
+## Prerequisites
+
+- brain initialized with PM module active
+- A PM task to work on (see [PM Quick Start](../pm-module/quickstart.md))
+
+---
+
+## 1. What Problem It Solves
+
+When multiple agents run in parallel, it's easy to lose track of which agent is doing what, which files it owns, and whether it completed successfully. The agent module provides a persistent registry so you can audit every agent run, trace cost, and ensure PM tasks are updated when work finishes — even across restarts.
+
+---
+
+## 2. Register an Agent
+
+Register an agent before spawning it. Provide a name, the PM task ID, and file ownership:
+
+```bash
+brain agent register \
+  --name "Implement search" \
+  --task MY-01-003 \
+  --branch feat/search \
+  --ownership "src/services/search.ts,src/commands/search.ts"
+```
+
+Output:
+
+```
+Agent registered: ag_7f3b2a1c
+Branch: feat/search
+Worktree: /path/to/repo/.worktrees/feat-search
+```
+
+---
+
+## 3. List Active Agents
+
+```bash
+brain agent list --status active
+```
+
+Output:
+
+```
+ag_7f3b2a1c  Implement search  active   MY-01-003  feat/search
+ag_2e9c4d5f  Write tests       pending  MY-02-001  feat/tests
+```
+
+Filter by status: `pending` | `active` | `completed` | `failed` | `abandoned`
+
+---
+
+## 4. Show Agent Detail
+
+```bash
+brain agent show ag_7f3b2a1c
+```
+
+Output:
+
+```
+ID:          ag_7f3b2a1c
+Name:        Implement search
+Status:      active
+Task:        MY-01-003
+Branch:      feat/search
+Worktree:    /path/to/repo/.worktrees/feat-search
+Ownership:   src/services/search.ts, src/commands/search.ts
+Started:     2026-04-27T10:00:00Z
+PID:         45231
+```
+
+---
+
+## 5. Agent Lifecycle
+
+Agents move through these states:
+
+```
+pending → active → completed
+                 → failed
+                 → abandoned
+```
+
+State transitions happen automatically when:
+- Agent process starts → `active`
+- Agent exits with code 0 → `completed` (done-handler fires)
+- Agent exits with non-zero → `failed`
+- Agent is manually stopped → `abandoned`
+
+---
+
+## 6. What Happens on Completion
+
+When the `agent-done` hook fires, the done-handler (`src/modules/agents/agent-done-handler.ts`):
+
+1. Marks the agent `completed` in the registry
+2. Releases its worktree allocation
+3. Links any commits and PRs as artifacts
+4. Marks the PM task done (if the agent held a claim token)
+
+---
+
+## 7. Migrate Legacy Agents
+
+If you have agents recorded in the old `ao.yaml` format:
+
+```bash
+brain agent migrate-ao
+```
+
+---
+
+## How It Works
+
+Agent records are stored in SQLite via `src/modules/agents/data.ts`. Each agent holds a `claim_token` from the PM module — this token is what authorizes the agent to transition its task to `done`. Worktree allocation is managed by `src/modules/agents/worktree.ts` and bounded by the `worktreeBudget` setting in `ao.config.json`.
+
+---
+
+## Related
+
+- Agent CRUD: `src/modules/agents/data.ts`
+- Worktree allocation: `src/modules/agents/worktree.ts`
+- Done-handler: `src/modules/agents/agent-done-handler.ts`
+- MCP tools: `brain_agent_list`, `brain_agent_status`, `brain_agent_dispatch`

--- a/docs/codebase/quickstart.md
+++ b/docs/codebase/quickstart.md
@@ -1,0 +1,114 @@
+# Codebase Indexing Quick Start
+
+The codebase module scans TypeScript source files and generates architecture notes — one per module — stored in brain as `type: architecture` notes. These notes make code structure searchable alongside your regular knowledge, and the post-merge hook keeps them automatically up-to-date.
+
+## Prerequisites
+
+- brain initialized and indexed
+- A TypeScript project to index
+
+---
+
+## 1. What Problem It Solves
+
+Understanding a large codebase requires reading files one by one. The codebase module extracts module purpose, exports, and dependencies into structured notes so you can search the architecture ("what handles webhook routing?"), ask brain about dependencies, or get a map of the codebase without opening an IDE.
+
+---
+
+## 2. Index the Codebase
+
+Run the indexer from the project root:
+
+```bash
+brain codebase index
+```
+
+Output:
+
+```
+Scanning: src/**/*.ts
+Files found: 87
+Modules analyzed: 87
+  Changed: 12
+  Unchanged: 75
+Notes written: 12
+```
+
+Only modules with changed exports are re-indexed on subsequent runs (hash-based change detection).
+
+---
+
+## 3. Index a Different Project
+
+```bash
+brain codebase index --project-dir /path/to/project --output-dir ~/brain/architecture/my-project
+```
+
+---
+
+## 4. Search Architecture Notes
+
+Once indexed, architecture notes are searchable with the standard brain search:
+
+```bash
+brain search "webhook routing"
+brain search "database migrations" --type architecture
+```
+
+Or via MCP:
+
+```
+brain_search  query="search orchestration"  type="architecture"
+```
+
+---
+
+## 5. Install the Post-Merge Hook
+
+Keep architecture notes current by installing a post-merge git hook:
+
+```bash
+brain codebase install-hook
+```
+
+This writes a hook to `.git/hooks/post-merge` that runs `brain codebase index` automatically after each `git merge` or `git pull`.
+
+---
+
+## What Each Architecture Note Contains
+
+For each module (`src/services/search.ts` → note `Architecture: src/services/search`):
+
+- **Purpose** — extracted from the module's leading JSDoc comment
+- **Exports** — function/class/type signatures
+- **Internal dependencies** — other src modules it imports
+- **External dependencies** — npm packages it uses
+- **Export hash** — SHA256 of the exports signature (used for change detection)
+
+Frontmatter example:
+
+```yaml
+title: "Architecture: src/services/search"
+type: architecture
+tier: slow
+module: codebase
+module-path: src/services/search
+language: typescript
+exports-hash: "a1b2c3..."
+tags: [architecture, typescript]
+```
+
+---
+
+## How It Works
+
+`discoverFiles` (`src/modules/codebase/scanner.ts`) glob-matches source files. `scanModules` parses each file's AST via `src/modules/codebase/extractors/typescript-extractor.ts`, extracting exports and dependencies. Modules whose `exports-hash` has changed since the last run are re-indexed. `generateNotes` (`src/modules/codebase/note-generator.ts`) writes the markdown notes into the brain workspace.
+
+---
+
+## Related
+
+- Scanner: `src/modules/codebase/scanner.ts`
+- Note generator: `src/modules/codebase/note-generator.ts`
+- TypeScript extractor: `src/modules/codebase/extractors/typescript-extractor.ts`
+- Hook installer: `src/modules/codebase/commands/install-hook.ts`

--- a/docs/hooks/quickstart.md
+++ b/docs/hooks/quickstart.md
@@ -1,0 +1,134 @@
+# Hook Dispatch Quick Start
+
+Brain's hook system intercepts Claude Code events (tool calls, session start, agent completion) and enforces configurable checks: file ownership boundaries, git safety, WIP limits, definition of done, worktree isolation, and friction detection. All checks run through a single dispatch entry point so new checks can be added without modifying Claude Code settings.
+
+## Prerequisites
+
+- brain installed and initialized
+- Claude Code project or user settings accessible
+
+---
+
+## 1. What Problem It Solves
+
+Without hooks, agents can accidentally write outside their assigned files, push to protected branches, or spiral into retry loops. Hooks act as a guardrail layer that runs before and after tool calls, enforcing invariants that would otherwise require manual review after every agent run.
+
+---
+
+## 2. Install Hooks
+
+Add brain hooks to your Claude Code project settings:
+
+```bash
+brain hook install --project    # writes to .claude/settings.json
+brain hook install --user       # writes to ~/.claude/settings.json
+```
+
+This registers `brain hook dispatch <event>` as the handler for each supported Claude Code hook event.
+
+---
+
+## 3. Check Hook Status
+
+See which checks are registered and enabled:
+
+```bash
+brain hook status
+```
+
+Output:
+
+```
+Registered checks (9):
+  ✓ file-ownership      pre-tool-use   [enabled]
+  ✓ git-safety          pre-tool-use   [enabled]
+  ✓ wip-limit           pre-tool-use   [enabled]
+  ✓ workspace           pre-tool-use   [enabled]
+  ✓ worktree-isolation  pre-tool-use   [enabled]
+  ✓ workflow-resource   pre-tool-use   [enabled]
+  ✓ friction            pre-tool-use   [enabled]
+  ✓ dod                 task-completed [enabled]
+  ✓ agents:agent-done   agent-done     [enabled]
+```
+
+---
+
+## 4. Configure Checks
+
+Checks are configured in `ao.config.json` in the project root. A minimal example:
+
+```json
+{
+  "hooks": {
+    "enforcement": {
+      "ownership": true,
+      "gitSafety": true,
+      "wipLimit": 5,
+      "dod": true,
+      "worktreeIsolation": true,
+      "friction": true
+    },
+    "ownershipManifest": ".claude/ownership.json"
+  }
+}
+```
+
+Set a value to `false` to disable that check project-wide.
+
+---
+
+## 5. Define File Ownership
+
+Create `.claude/ownership.json` to specify which agent or role owns which paths:
+
+```json
+{
+  "src/modules/pm/": "pm-agent",
+  "src/modules/workflow/": "workflow-agent",
+  "docs/": "docs-agent"
+}
+```
+
+The `file-ownership` check blocks writes to paths not owned by the current agent.
+
+---
+
+## 6. Dispatch a Hook Manually
+
+Test a hook by dispatching an event from the command line (JSON on stdin):
+
+```bash
+echo '{"tool":"Write","path":"src/foo.ts"}' | brain hook dispatch pre-tool-use
+```
+
+Exit code 0 = allowed, non-zero = blocked (stderr contains the reason).
+
+---
+
+## Built-in Checks
+
+| Check | Event | What It Enforces |
+|---|---|---|
+| `file-ownership` | `pre-tool-use` | Writes confined to owned paths |
+| `git-safety` | `pre-tool-use` | Blocks destructive ops on protected branches |
+| `wip-limit` | `pre-tool-use` | Max concurrent active agents (`wipLimit` in config) |
+| `workspace` | `pre-tool-use` | Task dispatch requires clean git state |
+| `worktree-isolation` | `pre-tool-use` | Agent confined to its allocated worktree |
+| `workflow-resource` | `pre-tool-use` | Tool calls validated against workflow resource allocations |
+| `friction` | `pre-tool-use` | Blocks consecutive failures of the same tool (retry spiral guard) |
+| `dod` | `task-completed` | Completion requires passing typecheck + tests + lint |
+| `agents:agent-done` | `agent-done` | Marks agent complete, releases worktree, updates PM task |
+
+---
+
+## How It Works
+
+`HookRegistry` (`src/hooks/registry.ts`) maintains a sorted list of handlers. `dispatchHookEvent` (`src/hooks/dispatch.ts`) is the CLI entry point — it reads the event payload from stdin, runs handlers in priority order, and stops on the first failure. Configuration is merged from global and project `ao.config.json` files via `resolveHookConfig` (`src/hooks/config.ts`).
+
+---
+
+## Related
+
+- Registry: `src/hooks/registry.ts`
+- Config resolution: `src/hooks/config.ts`
+- Built-in checks: `src/hooks/checks/`

--- a/docs/mcp/quickstart.md
+++ b/docs/mcp/quickstart.md
@@ -1,0 +1,139 @@
+# MCP Server Quick Start
+
+Brain exposes its full capability set as a Model Context Protocol (MCP) server, making search, PM, workflow, agent, and session tools available to Claude and any other MCP client. Two transport modes are available: stdio (for Claude Code integration) and HTTP+SSE (for the dashboard or custom clients).
+
+## Prerequisites
+
+- brain installed and initialized (`brain init`)
+- Claude Code or another MCP client
+
+---
+
+## 1. What Problem It Solves
+
+Brain's CLI is powerful but requires switching contexts. The MCP server lets Claude interact with your knowledge base, project tasks, and running workflows directly in-conversation — no shell commands needed. Claude can search notes, pick up tasks, dispatch agents, and stream workflow events without leaving the chat.
+
+---
+
+## 2. Start the MCP Server (Stdio)
+
+For Claude Code integration, add brain to your MCP config:
+
+```json
+{
+  "mcpServers": {
+    "brain": {
+      "command": "npx",
+      "args": ["tsx", "src/cli.ts", "serve", "--mcp"],
+      "cwd": "/path/to/brain"
+    }
+  }
+}
+```
+
+Or start it manually:
+
+```bash
+brain serve --mcp
+```
+
+---
+
+## 3. Start the HTTP Server (Dashboard / Custom Clients)
+
+```bash
+brain serve --port 3456
+```
+
+This starts both an HTTP endpoint and an SSE channel for push events. The dashboard connects to this.
+
+---
+
+## 4. Available Tools
+
+The server registers ~45 tools grouped by domain:
+
+**Search & Knowledge**
+
+| Tool | Description |
+|---|---|
+| `brain_search` | Hybrid BM25 + vector search across notes |
+| `brain_memory_search` | Search extracted memory facts |
+| `brain_note_read` | Fetch a note by ID or slug |
+| `brain_note_list` | List notes with filters |
+| `brain_memory_list` | List extracted memories |
+
+**Project Management**
+
+| Tool | Description |
+|---|---|
+| `brain_pm_next` | Eligible tasks ranked by priority |
+| `brain_pm_context` | PM context for the active project |
+| `brain_pm_overview` | High-level summary across workstreams |
+| `brain_pm_task_add` | Create a new task |
+| `brain_pm_task_update` | Update task fields |
+| `brain_pm_task_complete` | Mark a task done |
+| `brain_pm_wave` | Wave plan for remaining tasks |
+| `brain_dispatch_triage` | Triage and route incoming work |
+
+**Workflow**
+
+| Tool | Description |
+|---|---|
+| `brain_workflow_start` | Start a named workflow |
+| `brain_workflow_status` | Get run status and step results |
+| `brain_workflow_signal` | Signal an assisted step |
+| `brain_workflow_events` | Poll incremental events (with cursor) |
+
+**Agents**
+
+| Tool | Description |
+|---|---|
+| `brain_agent_list` | List agents with status filter |
+| `brain_agent_status` | Get agent detail |
+| `brain_agent_dispatch` | Dispatch an agent for a task |
+| `brain_agent_activity` | Recent agent activity log |
+
+**Inbox & Capture**
+
+| Tool | Description |
+|---|---|
+| `brain_inbox_add` | Add an item to the capture inbox |
+| `brain_note_add` | Create a new note |
+
+**Sessions & Advisor**
+
+| Tool | Description |
+|---|---|
+| `brain_session_list` | List ingested sessions |
+| `brain_session_show` | Session detail and segments |
+| `brain_advisor_ask` | Strategic question to Opus advisor |
+| `brain_advisor_review` | Request advisor review of a plan |
+
+---
+
+## 5. Example: Search and Pick Up a Task
+
+Inside a Claude conversation with brain MCP connected:
+
+```
+User: What's the next task for the VNM project?
+Claude: [calls brain_pm_next] → MY-01-003 (high priority, ELIGIBLE)
+
+User: Show me related context.
+Claude: [calls brain_pm_context, brain_search "MY-01-003"] → returns task detail + relevant notes
+```
+
+---
+
+## How It Works
+
+The server is initialized in `src/server/index.ts`. Tool handlers are registered in `src/server/mcp.ts`. On startup, the MCP server initializes the V2 workflow runtime and the merge lifecycle reconciler. Resource list change notifications are sent over the SSE channel when agent or workflow state changes.
+
+---
+
+## Related
+
+- Server entry: `src/server/index.ts`
+- Tool catalog: `src/server/mcp.ts`
+- Workflow runtime integration: `src/server/index.ts:initV2Runtime`

--- a/docs/sessions/quickstart.md
+++ b/docs/sessions/quickstart.md
@@ -1,0 +1,153 @@
+# Session Intelligence Quick Start
+
+The session module ingests Claude Code session JSONL files, extracts structured metadata, and generates summaries at multiple levels of detail. Sessions become searchable brain notes linked to PM tasks, enabling project briefings, analytics, and context restoration when resuming interrupted work.
+
+## Prerequisites
+
+- brain initialized and indexed
+- At least one Claude Code session JSONL file (typically under `~/.claude/projects/`)
+
+---
+
+## 1. What Problem It Solves
+
+Long agent sessions contain a wealth of information — decisions made, tasks completed, errors encountered — that disappears when the context window compacts. The session module preserves that history as structured notes, so you can answer questions like "what did we decide last Tuesday?" or "which tasks did last session's agent complete?" without re-reading raw JSONL.
+
+---
+
+## 2. Ingest Sessions
+
+Discover and ingest Claude Code session files:
+
+```bash
+brain session ingest
+```
+
+Output:
+
+```
+Discovered: 12 sessions
+Skipped (already ingested): 9
+Ingested: 3
+  SNS-041  2026-04-26  VNM  feat/search  45 min  completed
+  SNS-042  2026-04-27  VNM  feat/tests   22 min  completed
+  SNS-043  2026-04-27  VNM  main         8 min   active
+```
+
+To re-ingest an already-processed session: `brain session ingest --force`
+
+To ingest only recent sessions: `brain session ingest --since 2026-04-25`
+
+---
+
+## 3. List Sessions
+
+```bash
+brain session list
+```
+
+Output:
+
+```
+SNS-041  2026-04-26  VNM  feat/search   45 min  completed
+SNS-042  2026-04-27  VNM  feat/tests    22 min  completed
+SNS-043  2026-04-27  VNM  main           8 min  active
+```
+
+Filter by status: `brain session list --status active`
+
+---
+
+## 4. Show Session Detail
+
+```bash
+brain session show SNS-041
+```
+
+Shows:
+- L0 summary (one-liner)
+- Tasks worked and completed
+- Commits made
+- Token usage and tool call counts
+- Segments (compaction boundaries)
+- Error count
+
+---
+
+## 5. Restore Session Context
+
+When resuming after an interruption, restore the session context to brief your next agent:
+
+```bash
+brain session restore SNS-041
+```
+
+Output is a structured context block containing: what was in progress, last decisions, open tasks, and suggested next steps.
+
+---
+
+## 6. Get a Project Briefing
+
+Generate a current-state briefing across all recent sessions for a project:
+
+```bash
+brain session briefing
+```
+
+Output:
+
+```
+=== Project Briefing: VNM ===
+Active branch: feat/search
+Recent sessions: 3 (last: SNS-043, 8 min ago)
+Tasks in progress: MY-01-003, MY-01-004
+Last completed: MY-01-002 (SNS-042)
+Recommended next: MY-01-003 (implementation, high)
+```
+
+---
+
+## 7. View Analytics
+
+```bash
+brain session analytics
+```
+
+Shows session counts, average duration, task throughput, error rates, and tool usage by project.
+
+---
+
+## How It Works
+
+`discoverSessions` (`src/modules/sessions/ingestion/discovery.ts`) scans `~/.claude/projects/` for JSONL files. The ingestion pipeline (`src/modules/sessions/ingestion/pipeline.ts`) parses each file, generates a three-level summary (L0: one-liner, L1: key events, L2: timeline), detects task links, and creates a brain note with structured frontmatter. Sessions are stored as `type: session` notes with `module: sessions` isolation.
+
+Capture hooks fire during active sessions to record tool events and generate briefing context at session start.
+
+---
+
+## Session Note Fields
+
+Each ingested session note includes:
+
+```yaml
+session_id: <UUID>
+display_id: SNS-041
+project: VNM
+branch: feat/search
+status: completed
+duration_minutes: 45
+total_turns: 156
+tool_calls: 243
+tasks_worked: [MY-01-002, MY-01-003]
+tasks_completed: [MY-01-002]
+commits: [sha1, sha2]
+```
+
+---
+
+## Related
+
+- Ingestion pipeline: `src/modules/sessions/ingestion/pipeline.ts`
+- Discovery: `src/modules/sessions/ingestion/discovery.ts`
+- Capture hooks: `src/modules/sessions/hooks/`
+- MCP tools: `brain_session_list`, `brain_session_show`

--- a/docs/workflow/quickstart.md
+++ b/docs/workflow/quickstart.md
@@ -1,0 +1,118 @@
+# Workflow Runtime Quick Start
+
+The V2 workflow runtime lets you define multi-step agent pipelines as plain TypeScript async functions. Brain handles memoized dispatch (steps that already ran are not re-dispatched on restart), agent supervision, step output capture, and channel-based push events for live progress.
+
+## Prerequisites
+
+- brain running with MCP server active (`brain serve --mcp` or integrated via Claude Code)
+- Claude Code configured with the brain MCP server
+
+---
+
+## 1. What Problem It Solves
+
+Long agent tasks — planning, implementation, PR review — need to survive restarts, recover from failures, and sequence multiple agent steps without manual coordination. The workflow runtime provides a durable execution layer: workflows are persisted to the brain database and resume from their last completed step after a crash or restart.
+
+---
+
+## 2. Start a Workflow
+
+Workflows are launched via the `brain_workflow_start` MCP tool. Provide the workflow name and parameters:
+
+```
+brain_workflow_start  name="planning"  params='{"project":"MY","scope":"add search feature"}'
+```
+
+Response:
+
+```json
+{ "runId": "wf_abc123", "status": "running", "currentStep": "seed" }
+```
+
+Available workflows (defined in `src/modules/workflow/flows/`):
+
+| Name | Purpose |
+|---|---|
+| `planning` | Research → spec → acceptance criteria → task breakdown |
+| `implementation` | Seed context → agent dispatch → verify |
+| `review` | Code review with structured findings |
+| `brainstorming` | Creative exploration with iterative agent steps |
+| `pr-lifecycle` | PR open → CI → review → merge |
+| `ux-prototype` | Iterative UX design with feedback loops |
+
+---
+
+## 3. Check Status
+
+Poll for progress using the run ID:
+
+```
+brain_workflow_status  runId="wf_abc123"
+```
+
+Response:
+
+```json
+{
+  "runId": "wf_abc123",
+  "status": "running",
+  "currentStep": "implementation",
+  "stepResults": [
+    { "stepId": "seed", "completedAt": "2026-04-27T10:00:00Z" },
+    { "stepId": "research", "completedAt": "2026-04-27T10:02:00Z" }
+  ]
+}
+```
+
+Statuses: `running` | `completed` | `failed` | `paused` | `cancelled`
+
+---
+
+## 4. Stream Live Events
+
+Use `brain_workflow_events` to poll incremental updates (pass the cursor from each response as `since` in the next call):
+
+```
+brain_workflow_events  since="<cursor>"
+```
+
+Response includes new step completions, agent dispatches, and error events since the cursor.
+
+---
+
+## 5. Signal an Assisted Step
+
+Some workflows pause at `assisted` steps and wait for human input. Signal completion with data:
+
+```
+brain_workflow_signal  runId="wf_abc123"  stepId="scope-review"  data='{"approved":true}'
+```
+
+The workflow resumes from the next step.
+
+---
+
+## 6. View via CLI
+
+List running workflows from the terminal:
+
+```bash
+brain workflow list
+brain workflow show wf_abc123
+```
+
+---
+
+## How It Works
+
+Each workflow is a TypeScript async function `(ctx: WorkflowContext) => Promise<void>` registered in `src/modules/workflow/flows/index.ts`. Steps use `ctx.dispatch(stepId, template)` for agent work or `ctx.seed(stepId, fn)` for deterministic setup. Dispatch calls are memoized by `stepId` — restarting a workflow skips steps that already completed.
+
+The `WorkflowRuntime` (`src/modules/workflow/runtime/runtime.ts`) persists run state to SQLite, reconciles stalled runs on startup, and pushes events via MCP resource change notifications.
+
+---
+
+## Related
+
+- Workflow flows: `src/modules/workflow/flows/`
+- Runtime source: `src/modules/workflow/runtime/runtime.ts`
+- Context API: `src/modules/workflow/runtime/context.ts`


### PR DESCRIPTION
## Summary

Recovers the dangling commit from the original VNM-22.09 dispatch (2026-04-27), which was lost when the watchdog reclaim raced with orphan-recovery. The agent committed cleanly but its branch was deleted before push could land. See VNM-56.63 for the underlying race fix.

Adds scannable quickstart guides (matching docs/pm-module/quickstart.md depth) for six previously undocumented subsystems:

- workflow runtime
- MCP server
- hook dispatch
- agent module
- session intelligence
- codebase indexing

Updates README's Documentation section with links to all new and existing docs.

## Test plan
- [x] CI passes
- [ ] Spot-check docs against current src/ paths
- [ ] Confirm `git check-ignore docs/workflow/quickstart.md` does not block merged content