### PR TITLE
Defer worktree reclaim within 120s grace window (VNM-56.63)

### DIFF
--- a/__tests__/modules/agents/worktree.test.ts
+++ b/__tests__/modules/agents/worktree.test.ts
@@ -209,7 +209,10 @@ describe('worktree lifecycle', () => {
         parent: 'test',
         brain_task: 'VNM-09.01',
       });
-      updateAgentStatus(db, agentId, 'completed');
+      // Use an old completed_at so the reclaim grace window does not block.
+      updateAgentStatus(db, agentId, 'completed', {
+        completed_at: '2020-01-01T00:00:00.000Z',
+      });
 
       vi.clearAllMocks();
       mockExistsSync.mockReturnValue(true);
@@ -448,6 +451,10 @@ describe('worktree lifecycle', () => {
   // ── reclaimTerminatedAllocations ───────────────────────────────────────────
 
   describe('reclaimTerminatedAllocations', () => {
+    // Past the 120s grace window — bypasses the reclaim deferral guard so
+    // tests that just check terminal-status semantics aren't affected.
+    const OLD_TIMESTAMP = '2020-01-01T00:00:00.000Z';
+
     function allocateAndAttachAgent(taskId: string, status: 'completed' | 'failed' | 'abandoned') {
       allocateWorktree(db, '/repo', {
         taskId,
@@ -461,7 +468,7 @@ describe('worktree lifecycle', () => {
         parent: 'test',
         brain_task: taskId,
       });
-      updateAgentStatus(db, agentId, status);
+      updateAgentStatus(db, agentId, status, { completed_at: OLD_TIMESTAMP });
       return agentId;
     }
 
@@ -483,7 +490,7 @@ describe('worktree lifecycle', () => {
       ];
       ['VNM-09.01', 'VNM-09.02', 'VNM-09.03'].forEach((id, i) => {
         const agentId = createAgent(db, { name: `a-${id}`, parent: 't', brain_task: id });
-        updateAgentStatus(db, agentId, statuses[i]);
+        updateAgentStatus(db, agentId, statuses[i], { completed_at: OLD_TIMESTAMP });
       });
 
       vi.clearAllMocks();
@@ -552,6 +559,78 @@ describe('worktree lifecycle', () => {
 
     it('reclaims allocations whose delivery has finalized', () => {
       const agentId = allocateAndAttachAgent('VNM-09.01', 'completed');
+      recordDelivery(db, agentId, {
+        status: 'merged',
+        task_id: 'VNM-09.01',
+        branch: 'agent/ws-x/VNM-09.01',
+      });
+
+      vi.clearAllMocks();
+      mockExistsSync.mockReturnValue(true);
+
+      const reclaimed = reclaimTerminatedAllocations(db, '/repo');
+      expect(reclaimed).toEqual(['VNM-09.01']);
+      expect(getWorktreeAllocations(db)).toHaveLength(0);
+    });
+
+    it('defers reclaim within 120s grace window when no delivery exists', () => {
+      // Agent finished moments ago with no delivery row yet — orphan-recovery
+      // may still be running. Reconciler must not race-delete the branch.
+      allocateWorktree(db, '/repo', {
+        taskId: 'VNM-09.01',
+        workstream: 'ws-1',
+        claimToken: 'tok-1',
+        basePath: '.worktrees',
+        budget: 5,
+      });
+      const agentId = createAgent(db, {
+        name: 'a-1',
+        parent: 't',
+        brain_task: 'VNM-09.01',
+      });
+      const recent = new Date(Date.now() - 30_000).toISOString();
+      updateAgentStatus(db, agentId, 'completed', { completed_at: recent });
+
+      vi.clearAllMocks();
+      mockExistsSync.mockReturnValue(true);
+
+      const reclaimed = reclaimTerminatedAllocations(db, '/repo');
+      expect(reclaimed).toHaveLength(0);
+      expect(getWorktreeAllocations(db)).toHaveLength(1);
+    });
+
+    it('reclaims after grace window expires', () => {
+      allocateWorktree(db, '/repo', {
+        taskId: 'VNM-09.01',
+        workstream: 'ws-1',
+        claimToken: 'tok-1',
+        basePath: '.worktrees',
+        budget: 5,
+      });
+      const agentId = createAgent(db, {
+        name: 'a-1',
+        parent: 't',
+        brain_task: 'VNM-09.01',
+      });
+      const expired = new Date(Date.now() - 200_000).toISOString();
+      updateAgentStatus(db, agentId, 'completed', { completed_at: expired });
+
+      vi.clearAllMocks();
+      mockExistsSync.mockReturnValue(true);
+
+      const reclaimed = reclaimTerminatedAllocations(db, '/repo');
+      expect(reclaimed).toEqual(['VNM-09.01']);
+      expect(getWorktreeAllocations(db)).toHaveLength(0);
+    });
+
+    it('grace window does not apply once delivery row exists', () => {
+      // Once orphan-recovery (or any caller) creates a delivery row, reclaim
+      // semantics are governed by ACTIVE_DELIVERY_STATUSES, not the timer.
+      const agentId = allocateAndAttachAgent('VNM-09.01', 'completed');
+      // Override to a recent completed_at — grace-eligible — but with a
+      // finalized delivery, so reclaim still proceeds.
+      const recent = new Date(Date.now() - 5_000).toISOString();
+      updateAgentStatus(db, agentId, 'completed', { completed_at: recent });
       recordDelivery(db, agentId, {
         status: 'merged',
         task_id: 'VNM-09.01',

--- a/src/modules/agents/worktree.ts
+++ b/src/modules/agents/worktree.ts
@@ -44,6 +44,20 @@ const ACTIVE_DELIVERY_STATUSES: ReadonlySet<string> = new Set([
   'review-paused',
 ]);
 
+/**
+ * Grace window between agent.completed_at and reclaim eligibility.
+ *
+ * dispatch.ts:handleProcessExit runs orphan-recovery (push + open PR) async
+ * after marking the agent terminal. The reconciler ticks on its own 60s timer
+ * and races with that work. Without this window, an agent that committed but
+ * had not yet pushed could lose its branch — releaseWorktree does
+ * `git branch -D`, leaving the commit dangling.
+ *
+ * 120s easily covers a normal push + `gh pr create` round-trip; the next
+ * reconciler tick handles cleanup once a delivery row exists.
+ */
+const RECLAIM_GRACE_MS = 120_000;
+
 export interface AllocateWorktreeOptions {
   taskId: string;
   workstream: string;
@@ -230,9 +244,20 @@ export function reclaimTerminatedAllocations(db: unknown, projectRoot: string): 
     if (!agent) continue;
     if (!TERMINAL_AGENT_STATUSES.has(agent.status)) continue;
 
+    let delivery: ReturnType<typeof getDeliveryForTask> = null;
     if (rawDb) {
-      const delivery = getDeliveryForTask(rawDb, allocation.task_id);
+      delivery = getDeliveryForTask(rawDb, allocation.task_id);
       if (delivery && ACTIVE_DELIVERY_STATUSES.has(delivery.status)) continue;
+    }
+
+    // Grace window: defer reclaim of recently-completed agents whose
+    // orphan-recovery has not yet created a delivery row. Without this guard
+    // the reconciler races with dispatch.ts:handleProcessExit's push + PR.
+    if (!delivery && agent.completed_at) {
+      const completedMs = Date.parse(agent.completed_at);
+      if (!Number.isNaN(completedMs) && Date.now() - completedMs < RECLAIM_GRACE_MS) {
+        continue;
+      }
     }
 
     if (releaseWorktree(db, projectRoot, allocation.task_id)) {


### PR DESCRIPTION
## Summary

Fixes the critical race surfaced by the 2026-04-27 3-agent parallel dispatch test, where VNM-22.09 committed cleanly but its branch was deleted by `releaseWorktree` before `recoverBranchForAgent` could push — leaving commit `8060a59` dangling.

`reclaimTerminatedAllocations` in `src/modules/agents/worktree.ts` now skips agents whose `completed_at` is within a 120s grace window AND have no delivery row yet. Once orphan-recovery creates a delivery row, the existing `ACTIVE_DELIVERY_STATUSES` guard takes over. The window only covers the gap between agent-terminal-status and orphan-recovery's first DB write.

Pairs with #208 (recovers the dangling 8060a59 from the original incident).

## Test plan
- [x] 4 new regression tests in `__tests__/modules/agents/worktree.test.ts` (defer / expire / delivery-finalized / delivery-active)
- [x] All 624 agent module tests pass (37 worktree-specific)
- [x] All 1173 tests pass in pre-commit hook
- [ ] CI green
- [ ] After merge: re-run 3-agent parallel dispatch and confirm all 3 PRs land cleanly