### PR TITLE
Narrow docs/ gitignore to ephemeral subdirs (VNM-56.68)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,14 @@
 node_modules/
 dist/
 !dist/dashboard/index.html
-docs/
-!docs/plans/
+# Agent-generated outputs in docs/ — ephemeral, not for tracking.
+# Canonical user-facing docs (docs/pm-module/, docs/workflow/, docs/mcp/, etc.)
+# are NOT ignored — they should be committed normally.
+docs/audit-reports/
+docs/audits/
+docs/prototypes/
+docs/reviews/
+docs/demos.md
 *.db
 .env
 coverage/


### PR DESCRIPTION
## Summary

The blanket `docs/` ignore (added 2026-02-25 in dac2ddc) silently blocks agents from committing canonical user-facing docs. VNM-22.09 hit this on its first `git add` and only recovered with `git add -f` — the friction contributed to losing the orphan-recovery race fixed in #209.

Replaces `docs/` + `!docs/plans/` with explicit patterns for ephemeral agent outputs:
- `docs/audit-reports/`
- `docs/audits/`
- `docs/prototypes/`
- `docs/reviews/`
- `docs/demos.md`

Canonical docs (`docs/pm-module/`, `docs/workflow/`, `docs/mcp/`, `docs/agents/`, `docs/sessions/`, `docs/codebase/`, `docs/hooks/`, `docs/plans/`) are now committable without `-f`.

## Test plan
- [x] `git check-ignore docs/workflow/quickstart.md` returns nothing (canonical doc, allowed)
- [x] `git check-ignore docs/audit-reports/foo.md` reports the new rule (still ignored)
- [x] No new untracked files exposed (docs/plans/* were already visible via the prior whitelist)