### PR TITLE
Tighten worker prompt: never report DONE without commit (VNM-56.65)

### DIFF
--- a/templates/agents/worker.md
+++ b/templates/agents/worker.md
@@ -72,6 +72,20 @@ git commit -m "<imperative mood summary>"
 
 Keep the commit message under 72 characters. One logical change per commit.
 
+**Commit ALL artifacts.** If the task description includes a DELIVERABLE,
+REPORT, or any output artifact (markdown, JSON, generated code, audit
+findings), that artifact must be in this commit. A file written into your
+worktree is not "delivered" — it is destroyed when the worktree is
+reclaimed. **A research/audit task is not complete until the report is
+committed.** If your authorized scope does not include a sensible
+location for the artifact, write a `FAILED <reason>` instead of a
+silent un-committed file — the coordinator will route the task with an
+adjusted scope.
+
+If `git add` is rejected by `.gitignore` for a path you intend to
+commit (e.g., a new docs/ subdir), use `git add -f <path>` only after
+confirming the path is canonical user content (not generated/ephemeral).
+
 ### 5. Report completion
 
 Send a message to the coordinator via SendMessage:
@@ -95,3 +109,8 @@ Then exit. Do not continue working after sending the completion message.
 - Do not skip verification. All tests must pass.
 - Do not amend existing commits. Create new commits only.
 - If blocked by an issue outside your scope, report FAILED with a clear explanation.
+- **Never report DONE without a commit.** A task whose work lives only in
+  your worktree (uncommitted file edits, unstaged report.md) will be
+  destroyed by the post-exit reconciler. If you cannot commit your work
+  for any reason — gitignore conflict, missing scope, hook block — report
+  FAILED with the reason instead of DONE.


### PR DESCRIPTION
## Summary

VNM-56.59 (haiku audit, 2026-04-27) wrote its audit report into the worktree and reported DONE without committing. The post-exit reconciler reclaimed the worktree and the report was destroyed.

Strengthens \`templates/agents/worker.md\` step 4 (Commit) with explicit guidance about DELIVERABLE/REPORT artifacts, and adds a hard constraint forbidding DONE-without-commit. Pairs with #209 (reclaim grace window) and the upcoming VNM-56.64 (defense-in-depth: refuse reclaim of dirty worktrees).

## Test plan
- [x] 32 prompt-related tests still pass
- [ ] Re-run VNM-56.59 dispatch and confirm the audit report is committed