### PR TITLE
Refuse worktree release when dirty or unpushed (VNM-56.64)

### DIFF
--- a/__tests__/modules/agents/worktree.test.ts
+++ b/__tests__/modules/agents/worktree.test.ts
@@ -336,18 +336,103 @@ describe('worktree lifecycle', () => {
       });
 
       vi.clearAllMocks();
-      // First call (git worktree remove) throws; second call (--force) should succeed
-      mockExecFileSync
-        .mockImplementationOnce(() => {
+      // Inspection calls (status, rev-list) return clean. Then `git worktree
+      // remove` throws (locked/dirty); `--force` fallback should succeed.
+      mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
+        const argv = args as string[];
+        if (argv[0] === 'status' || argv[0] === 'rev-list' || argv[0] === 'rev-parse') {
+          return '';
+        }
+        if (argv[0] === 'worktree' && argv[1] === 'remove' && !argv.includes('--force')) {
           throw new Error('dirty');
-        })
-        .mockReturnValue('');
+        }
+        return '';
+      });
 
       const released = releaseWorktree(db, '/repo', 'VNM-09.01');
 
       expect(released).toBe(true);
       const calls = mockExecFileSync.mock.calls.map((c) => (c as string[][])[1]);
       expect(calls.some((args) => args.includes('--force'))).toBe(true);
+    });
+
+    it('refuses to release when worktree has uncommitted changes', () => {
+      allocateWorktree(db, '/repo', {
+        taskId: 'VNM-09.01',
+        workstream: 'vnm-09',
+        claimToken: 'tok-1',
+        basePath: '.worktrees',
+        budget: 3,
+      });
+
+      vi.clearAllMocks();
+      mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
+        const argv = args as string[];
+        if (argv[0] === 'status' && argv.includes('--porcelain')) {
+          return ' M src/foo.ts\n?? new-file.md\n';
+        }
+        return '';
+      });
+
+      const released = releaseWorktree(db, '/repo', 'VNM-09.01');
+      expect(released).toBe(false);
+      // Still in DB — dirty state preserved for human rescue.
+      expect(getWorktreeAllocations(db)).toHaveLength(1);
+    });
+
+    it('refuses to release when branch has unpushed commits', () => {
+      allocateWorktree(db, '/repo', {
+        taskId: 'VNM-09.01',
+        workstream: 'vnm-09',
+        claimToken: 'tok-1',
+        basePath: '.worktrees',
+        budget: 3,
+      });
+
+      vi.clearAllMocks();
+      mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
+        const argv = args as string[];
+        if (argv[0] === 'status' && argv.includes('--porcelain')) return '';
+        if (
+          argv[0] === 'rev-list' &&
+          argv.includes('--count') &&
+          argv.some((a) => a.startsWith('origin/main..'))
+        ) {
+          return '2\n';
+        }
+        if (argv[0] === 'rev-parse' && argv.includes('--verify')) {
+          throw new Error('unknown ref'); // origin branch missing → unpushed
+        }
+        return '';
+      });
+
+      const released = releaseWorktree(db, '/repo', 'VNM-09.01');
+      expect(released).toBe(false);
+      expect(getWorktreeAllocations(db)).toHaveLength(1);
+    });
+
+    it('force=true bypasses the safety check', () => {
+      allocateWorktree(db, '/repo', {
+        taskId: 'VNM-09.01',
+        workstream: 'vnm-09',
+        claimToken: 'tok-1',
+        basePath: '.worktrees',
+        budget: 3,
+      });
+
+      vi.clearAllMocks();
+      // Same dirty mock as the refuses-to-release case
+      mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
+        const argv = args as string[];
+        if (argv[0] === 'status' && argv.includes('--porcelain')) {
+          return ' M src/foo.ts\n';
+        }
+        return '';
+      });
+
+      const released = releaseWorktree(db, '/repo', 'VNM-09.01', { force: true });
+      expect(released).toBe(true);
+      expect(getWorktreeAllocations(db)).toHaveLength(0);
     });
 
     it('returns false when task has no allocation', () => {

--- a/src/modules/agents/worktree.ts
+++ b/src/modules/agents/worktree.ts
@@ -156,13 +156,102 @@ export function allocateWorktree(
 }
 
 /**
- * Release a worktree by task ID: remove from git, delete branch, remove from DB.
- * Returns false if no allocation exists for the given taskId.
+ * Inspect a worktree's safety to release. Returns flags for callers that
+ * want to preserve uncommitted edits or unpushed commits.
+ *
+ * - dirty: `git status --porcelain` is non-empty (untracked or modified files).
+ * - unpushed: branch has commits not present on origin (or origin missing).
  */
-export function releaseWorktree(db: unknown, projectRoot: string, taskId: string): boolean {
+export interface WorktreeReleaseSafety {
+  dirty: boolean;
+  unpushed: boolean;
+}
+
+export function inspectWorktreeForRelease(
+  worktreePath: string,
+  branch: string,
+  projectRoot: string
+): WorktreeReleaseSafety {
+  let dirty = false;
+  try {
+    const out = execFileSync('git', ['status', '--porcelain'], {
+      cwd: worktreePath,
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    });
+    dirty = out.trim().length > 0;
+  } catch {
+    // Worktree directory missing — treat as not-dirty so reclaim can proceed.
+    dirty = false;
+  }
+
+  let unpushed = false;
+  try {
+    const out = execFileSync('git', ['rev-list', '--count', `origin/main..${branch}`], {
+      cwd: projectRoot,
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    });
+    const ahead = parseInt(out.trim(), 10);
+    if (Number.isFinite(ahead) && ahead > 0) {
+      // Branch has commits past main. Check whether origin has the branch ref.
+      try {
+        execFileSync('git', ['rev-parse', '--verify', `origin/${branch}`], {
+          cwd: projectRoot,
+          encoding: 'utf-8',
+          stdio: 'pipe',
+        });
+        const aheadOfRemote = execFileSync(
+          'git',
+          ['rev-list', '--count', `origin/${branch}..${branch}`],
+          { cwd: projectRoot, encoding: 'utf-8', stdio: 'pipe' }
+        );
+        unpushed = parseInt(aheadOfRemote.trim(), 10) > 0;
+      } catch {
+        // Branch not on remote at all → its commits are unpushed.
+        unpushed = true;
+      }
+    }
+  } catch {
+    unpushed = false;
+  }
+
+  return { dirty, unpushed };
+}
+
+export interface ReleaseWorktreeOptions {
+  /** Bypass the dirty/unpushed safety check. Use for explicit destruction. */
+  force?: boolean;
+}
+
+/**
+ * Release a worktree by task ID: remove from git, delete branch, remove from DB.
+ * Returns false if no allocation exists, OR if the worktree has uncommitted
+ * changes or unpushed commits (unless `force: true` is set). Refusing to
+ * release in the unsafe case prevents the post-exit reconciler from racing
+ * orphan-recovery (VNM-56.63) and from destroying agent work that was
+ * written to the worktree but never committed (VNM-56.59).
+ */
+export function releaseWorktree(
+  db: unknown,
+  projectRoot: string,
+  taskId: string,
+  opts: ReleaseWorktreeOptions = {}
+): boolean {
   const allocations = getWorktreeAllocations(db);
   const allocation = allocations.find((a) => a.task_id === taskId);
   if (!allocation) return false;
+
+  if (!opts.force) {
+    const safety = inspectWorktreeForRelease(
+      allocation.worktree_path,
+      allocation.branch,
+      projectRoot
+    );
+    if (safety.dirty || safety.unpushed) {
+      return false;
+    }
+  }
 
   try {
     execFileSync('git', ['worktree', 'remove', allocation.worktree_path], {


### PR DESCRIPTION
## Summary

Defense-in-depth for the autonomy regression surfaced 2026-04-27. \`releaseWorktree\` previously did \`git worktree remove --force\` unconditionally, silently destroying:

1. Uncommitted edits in the worktree (the VNM-56.59 audit-report case)
2. Commits past origin/main not yet pushed (the VNM-22.09 dangling-commit case)

Now inspects the worktree first:
- \`git status --porcelain\` non-empty → dirty → refuse
- branch ahead of \`origin/<branch>\` (or origin missing) → unpushed → refuse

The allocation row stays in the DB; next reconciler tick re-evaluates. Callers that explicitly want destruction pass \`{ force: true }\`.

Pairs with #209 (reclaim grace window) and #211 (worker-prompt commit discipline). Together these three fixes close the destruction paths exposed by the 3-agent parallel test.

## Test plan
- [x] 4 new regression tests (dirty / unpushed / force-bypass / pre-existing force-fallback)
- [x] All 638 agent module tests pass
- [x] All 1173 tests pass in pre-commit
- [ ] CI green
- [ ] After merge: re-run 3-agent parallel dispatch, confirm no work is lost