### PR TITLE
Auto-takeover stale brain daemon on EADDRINUSE (VNM-56.70)

### DIFF
--- a/__tests__/commands/serve.test.ts
+++ b/__tests__/commands/serve.test.ts
@@ -454,6 +454,113 @@ describe('createHttpHandler — route matching', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Port-takeover endpoints (VNM-56.70)
+// ---------------------------------------------------------------------------
+
+function makeReqWithBody(
+  method: string,
+  url: string,
+  body: string,
+  remoteAddress = '127.0.0.1'
+): IncomingMessage {
+  const handlers: Record<string, Array<(...args: unknown[]) => void>> = {};
+  return {
+    method,
+    url,
+    socket: { remoteAddress },
+    on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+      (handlers[event] ??= []).push(cb);
+      // Synchronously fire body events for readBody() before the handler awaits.
+      if (event === 'data' && body) {
+        for (const cb2 of handlers['data'] ?? []) cb2(Buffer.from(body));
+      }
+      if (event === 'end') {
+        for (const cb2 of handlers['end'] ?? []) cb2();
+      }
+    }),
+  } as unknown as IncomingMessage;
+}
+
+describe('createHttpHandler — port-takeover endpoints', () => {
+  let service: ReturnType<typeof makeService>;
+  let sseClients: SseClients;
+
+  beforeEach(() => {
+    service = makeService();
+    sseClients = new Set();
+  });
+
+  it('/api/info returns brain identity and dbPath', async () => {
+    const handler = createHttpHandler(service as unknown as BrainServiceClass, sseClients);
+    const res = makeMockRes();
+    await handler(makeReq('GET', '/api/info'), res as unknown as ServerResponse);
+    const body = JSON.parse(res.body);
+    expect(body.brain).toBe(true);
+    expect(body.dbPath).toBe('/tmp/test.db');
+    expect(typeof body.pid).toBe('number');
+  });
+
+  it('/api/shutdown rejects non-localhost callers with 403', async () => {
+    const onShutdownRequest = vi.fn();
+    const handler = createHttpHandler(service as unknown as BrainServiceClass, sseClients, {
+      onShutdownRequest,
+    });
+    const res = makeMockRes();
+    await handler(
+      makeReqWithBody('POST', '/api/shutdown', '{"dbPath":"/tmp/test.db"}', '8.8.8.8'),
+      res as unknown as ServerResponse
+    );
+    expect(res.writeHead).toHaveBeenCalledWith(403, expect.any(Object));
+    expect(onShutdownRequest).not.toHaveBeenCalled();
+  });
+
+  it('/api/shutdown rejects mismatched dbPath with 403', async () => {
+    const onShutdownRequest = vi.fn();
+    const handler = createHttpHandler(service as unknown as BrainServiceClass, sseClients, {
+      onShutdownRequest,
+    });
+    const res = makeMockRes();
+    await handler(
+      makeReqWithBody('POST', '/api/shutdown', '{"dbPath":"/tmp/other.db"}'),
+      res as unknown as ServerResponse
+    );
+    expect(res.writeHead).toHaveBeenCalledWith(403, expect.any(Object));
+    expect(onShutdownRequest).not.toHaveBeenCalled();
+  });
+
+  it('/api/shutdown calls onShutdownRequest when localhost + dbPath match', async () => {
+    const onShutdownRequest = vi.fn();
+    const handler = createHttpHandler(service as unknown as BrainServiceClass, sseClients, {
+      onShutdownRequest,
+    });
+    const res = makeMockRes();
+    await handler(
+      makeReqWithBody('POST', '/api/shutdown', '{"dbPath":"/tmp/test.db"}'),
+      res as unknown as ServerResponse
+    );
+    expect(res.writeHead).toHaveBeenCalledWith(
+      200,
+      expect.objectContaining({ 'Content-Type': 'application/json' })
+    );
+    // Shutdown is dispatched via setTimeout to allow the response to flush.
+    await new Promise((r) => setTimeout(r, 80));
+    expect(onShutdownRequest).toHaveBeenCalledOnce();
+  });
+
+  it('/api/shutdown without options.onShutdownRequest is a no-op (no crash)', async () => {
+    const handler = createHttpHandler(service as unknown as BrainServiceClass, sseClients);
+    const res = makeMockRes();
+    await handler(
+      makeReqWithBody('POST', '/api/shutdown', '{"dbPath":"/tmp/test.db"}'),
+      res as unknown as ServerResponse
+    );
+    expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object));
+    await new Promise((r) => setTimeout(r, 80));
+    // No assertion on the callback — just no crash.
+  });
+});
+
 describe('broadcast', () => {
   it('sends formatted SSE message to all clients', () => {
     const clients: SseClients = new Set();

--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -47,9 +47,14 @@ function readBody(req: IncomingMessage): Promise<string> {
   });
 }
 
+export interface HttpHandlerOptions {
+  onShutdownRequest?: () => void;
+}
+
 export function createHttpHandler(
   service: BrainServiceClass,
-  sseClients: SseClients
+  sseClients: SseClients,
+  options: HttpHandlerOptions = {}
 ): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
   return async (req, res) => {
     setCors(res);
@@ -62,6 +67,45 @@ export function createHttpHandler(
 
     const url = new URL(req.url ?? '/', `http://localhost`);
     const path = url.pathname;
+
+    // Identity probe used by `brain serve` startup to confirm the existing
+    // listener is a brain instance for the same project before attempting to
+    // take over the port. The {brain: true} shape is the contract.
+    if (path === '/api/info' && req.method === 'GET') {
+      json(res, {
+        brain: true,
+        pid: process.pid,
+        dbPath: service.config.dbPath,
+      });
+      return;
+    }
+
+    // Graceful-shutdown signal sent by a fresh `brain serve` startup that
+    // wants to claim our port. Localhost-only and gated by dbPath match so
+    // unrelated callers cannot kill the daemon.
+    if (path === '/api/shutdown' && req.method === 'POST') {
+      const remote = req.socket.remoteAddress ?? '';
+      const isLocal = remote === '127.0.0.1' || remote === '::1' || remote === '::ffff:127.0.0.1';
+      if (!isLocal) {
+        json(res, { error: 'Forbidden: localhost only' }, 403);
+        return;
+      }
+      const body = await readBody(req);
+      let parsed: { dbPath?: string } = {};
+      try {
+        parsed = JSON.parse(body) as { dbPath?: string };
+      } catch {
+        // empty or malformed body — proceed with mismatch check below
+      }
+      if (parsed.dbPath !== service.config.dbPath) {
+        json(res, { error: 'Forbidden: dbPath mismatch' }, 403);
+        return;
+      }
+      json(res, { ok: true, pid: process.pid });
+      // Defer exit so the response can flush.
+      setTimeout(() => options.onShutdownRequest?.(), 50);
+      return;
+    }
 
     if (path === '/api/dashboard' && req.method === 'GET') {
       json(res, service.dashboard());

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -167,6 +167,96 @@ export function createServeServer(service: BrainServiceClass): McpServer {
   return server;
 }
 
+/**
+ * If a previous brain daemon is still bound to the port — likely because the
+ * user rebuilt and did NOT kill the old process — politely ask it to exit
+ * and then claim the port. Only takes over when the listener self-identifies
+ * as brain AND its dbPath matches ours, so unrelated services on the same
+ * port (or daemons for a different project) are left alone.
+ */
+async function takeoverStalePort(port: number, dbPath: string): Promise<boolean> {
+  const base = `http://127.0.0.1:${port}`;
+  try {
+    const infoRes = await fetch(`${base}/api/info`, { signal: AbortSignal.timeout(1500) });
+    if (!infoRes.ok) return false;
+    const info = (await infoRes.json()) as { brain?: boolean; dbPath?: string };
+    if (info.brain !== true || info.dbPath !== dbPath) return false;
+  } catch {
+    return false;
+  }
+
+  try {
+    const shutdownRes = await fetch(`${base}/api/shutdown`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ dbPath }),
+      signal: AbortSignal.timeout(1500),
+    });
+    if (!shutdownRes.ok) return false;
+  } catch {
+    return false;
+  }
+
+  // Poll for the port to free. The old process exits ~50ms after responding.
+  for (let i = 0; i < 30; i++) {
+    await new Promise((r) => setTimeout(r, 100));
+    if (await isPortFree(port)) return true;
+  }
+  return false;
+}
+
+function isPortFree(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const probe = createServer();
+    probe.once('error', () => resolve(false));
+    probe.once('listening', () => probe.close(() => resolve(true)));
+    probe.listen(port, '127.0.0.1');
+  });
+}
+
+async function listenWithTakeover(
+  service: BrainServiceClass,
+  sseClients: SseClients,
+  port: number,
+  onShutdownRequest: () => void
+): Promise<ReturnType<typeof createServer> | undefined> {
+  const tryListen = (): Promise<{ server: ReturnType<typeof createServer>; bound: boolean }> =>
+    new Promise((resolve) => {
+      const server = createServer(createHttpHandler(service, sseClients, { onShutdownRequest }));
+      const onError = (err: NodeJS.ErrnoException) => {
+        if (err.code === 'EADDRINUSE') {
+          server.close();
+          resolve({ server, bound: false });
+        } else {
+          throw err;
+        }
+      };
+      server.once('error', onError);
+      server.listen(port, () => {
+        server.removeListener('error', onError);
+        resolve({ server, bound: true });
+      });
+    });
+
+  let attempt = await tryListen();
+  if (attempt.bound) return attempt.server;
+
+  const tookOver = await takeoverStalePort(port, service.config.dbPath);
+  if (!tookOver) {
+    process.stderr.write(
+      `Port ${port} held by another process — running MCP stdio only (dashboard unavailable)\n`
+    );
+    return undefined;
+  }
+
+  process.stderr.write(`Replaced stale brain daemon on port ${port}\n`);
+  attempt = await tryListen();
+  if (attempt.bound) return attempt.server;
+
+  process.stderr.write(`Port ${port} reclaimed by something else — running MCP stdio only\n`);
+  return undefined;
+}
+
 export async function startServeServer(resolveOpts?: ResolveOptions, port = 7800): Promise<void> {
   const service = await BrainServiceClass.create(resolveOpts);
 
@@ -180,34 +270,24 @@ export async function startServeServer(resolveOpts?: ResolveOptions, port = 7800
   let heartbeat: ReturnType<typeof setInterval> | undefined;
   let httpServer: ReturnType<typeof createServer> | undefined;
 
-  if (port > 0) {
-    httpServer = createServer(createHttpHandler(service, sseClients));
-    httpServer.on('error', (err: NodeJS.ErrnoException) => {
-      if (err.code === 'EADDRINUSE') {
-        process.stderr.write(
-          `Port ${port} in use — running MCP stdio only (dashboard served by another session)\n`
-        );
-        httpServer = undefined;
-      } else {
-        throw err;
-      }
-    });
-    httpServer.listen(port, () => {
-      process.stderr.write(`Dashboard: http://localhost:${port}\n`);
-      process.stderr.write(`API: http://localhost:${port}/api/dashboard\n`);
-    });
-
-    heartbeat = setInterval(() => {
-      broadcast(sseClients, 'heartbeat', { ts: Date.now() });
-    }, 30_000);
-  }
-
   const shutdown = () => {
     if (heartbeat) clearInterval(heartbeat);
     if (httpServer) httpServer.close();
     service.close();
     process.exit(0);
   };
+
+  if (port > 0) {
+    httpServer = await listenWithTakeover(service, sseClients, port, shutdown);
+    if (httpServer) {
+      process.stderr.write(`Dashboard: http://localhost:${port}\n`);
+      process.stderr.write(`API: http://localhost:${port}/api/dashboard\n`);
+      heartbeat = setInterval(() => {
+        broadcast(sseClients, 'heartbeat', { ts: Date.now() });
+      }, 30_000);
+    }
+  }
+
   process.on('SIGINT', () => shutdown());
   process.on('SIGTERM', () => shutdown());
 


### PR DESCRIPTION
## Summary

Closes the painful "/mcp doesn't actually restart the daemon" gap surfaced 2026-04-27. After this lands, \`npm run build && /mcp\` will pick up today's code without any manual \`pkill\`. The new daemon notices the port-holder is a brain instance for the same project, asks it to exit, and reclaims the port.

## Mechanism

Two new HTTP endpoints on the running daemon:
- \`GET /api/info\` — self-identifies as brain, returns \`{ brain: true, pid, dbPath }\`
- \`POST /api/shutdown\` — gated on (a) localhost-only socket, (b) \`dbPath\` match in body — then triggers the existing graceful shutdown (close http, close service, exit 0)

Startup logic (\`listenWithTakeover\` in src/commands/serve.ts):
1. Try to bind. If success, done.
2. On EADDRINUSE: GET \`/api/info\` from the port-holder.
3. If it's a brain daemon for the same dbPath, POST \`/api/shutdown\`, poll until the port frees, retry the bind.
4. If the port-holder is non-brain, a different project, or missing /api/info, fall through to the previous "MCP stdio only" behaviour.

## Safety

- localhost-only gate prevents off-machine callers from killing the daemon
- dbPath gate prevents brain instances for OTHER projects from clobbering each other (multiple brains on different ports/projects coexist as before)
- 1.5s timeouts on both fetches so a hung old daemon doesn't block startup
- 3s total polling window for the port to free; if it doesn't, fall back

## Test plan
- [x] 5 new unit tests covering both endpoints (info shape, 403 non-localhost, 403 dbPath mismatch, success path triggers callback, missing-callback no-op)
- [x] All 39 serve tests pass; full pre-commit suite (1173 tests) passes
- [ ] Manual: rebuild + /mcp without killing the old daemon → confirm new code is live (verify with \`/api/info\` showing today's pid)