### PR TITLE
Advance delivery + PM task on observed PR-terminal state (VNM-56.71)

### DIFF
--- a/__tests__/services/merge-lifecycle-reconciler.test.ts
+++ b/__tests__/services/merge-lifecycle-reconciler.test.ts
@@ -24,6 +24,11 @@ vi.mock('../../src/modules/agents/worktree.js', () => ({
 
 vi.mock('../../src/modules/agents/delivery.js', () => ({
   enableAutoMerge: vi.fn(),
+  updateDeliveryStatus: vi.fn(),
+}));
+
+vi.mock('../../src/modules/pm/data/task-ops.js', () => ({
+  updateTaskStatus: vi.fn(() => Promise.resolve({ ok: true, value: {} })),
 }));
 
 vi.mock('../../src/server/orchestration.js', () => ({
@@ -42,9 +47,10 @@ import {
 import { getPrForBranch, rerunPrChecks } from '../../src/modules/agents/auto-merge.js';
 import { rebaseInIsolationDetailed } from '../../src/modules/agents/rebase-isolation.js';
 import { reclaimTerminatedAllocations } from '../../src/modules/agents/worktree.js';
-import { enableAutoMerge } from '../../src/modules/agents/delivery.js';
+import { enableAutoMerge, updateDeliveryStatus } from '../../src/modules/agents/delivery.js';
 import { recoverBranchForAgent } from '../../src/server/orchestration.js';
 import { loadFlakyTests } from '../../src/modules/agents/delivery-monitor.js';
+import { updateTaskStatus } from '../../src/modules/pm/data/task-ops.js';
 
 const mockGetPr = vi.mocked(getPrForBranch);
 const mockRerun = vi.mocked(rerunPrChecks);
@@ -53,6 +59,8 @@ const mockReclaim = vi.mocked(reclaimTerminatedAllocations);
 const mockArm = vi.mocked(enableAutoMerge);
 const mockRecover = vi.mocked(recoverBranchForAgent);
 const mockFlaky = vi.mocked(loadFlakyTests);
+const mockUpdateDelivery = vi.mocked(updateDeliveryStatus);
+const mockUpdateTask = vi.mocked(updateTaskStatus);
 
 interface PreparedQuery {
   sql: string;
@@ -228,16 +236,79 @@ describe('reconcileMergeLifecycle', () => {
     expect(report.ciReruns).toEqual(['agent/vnm-1/VNM-1.1']);
   });
 
-  it('skips PRs that are not currently open', async () => {
+  it('advances delivery state to merged when GH reports the PR merged', async () => {
     const db = makeDbMock([makeDelivery()]);
-    mockGetPr.mockReturnValue(makePr({ state: 'merged' }));
+    mockGetPr.mockReturnValue(makePr({ state: 'merged', mergedAt: '2026-04-28T12:00:00Z' }));
 
     const report = await reconcileMergeLifecycle(db as unknown as object, projectDir);
 
+    expect(mockUpdateDelivery).toHaveBeenCalledWith(db, 'agent-1', 'merged', {
+      pr_merged_at: '2026-04-28T12:00:00Z',
+    });
     expect(mockRebase).not.toHaveBeenCalled();
     expect(mockRerun).not.toHaveBeenCalled();
     expect(mockArm).not.toHaveBeenCalled();
+    expect(report.deliveriesMerged).toEqual(['VNM-1.1']);
     expect(report.prsScanned).toBe(1);
+  });
+
+  it('advances delivery state to stalled when GH reports the PR closed without merge', async () => {
+    const db = makeDbMock([makeDelivery()]);
+    mockGetPr.mockReturnValue(makePr({ state: 'closed' }));
+
+    const report = await reconcileMergeLifecycle(db as unknown as object, projectDir);
+
+    expect(mockUpdateDelivery).toHaveBeenCalledWith(db, 'agent-1', 'stalled', {
+      stall_reason: 'pr-closed',
+    });
+    expect(report.deliveriesClosed).toEqual(['VNM-1.1']);
+    expect(report.deliveriesMerged).toEqual([]);
+  });
+
+  it('advances PM task to done when pmDeps wired and PR merged', async () => {
+    const db = makeDbMock([makeDelivery()]);
+    mockGetPr.mockReturnValue(makePr({ state: 'merged', mergedAt: '2026-04-28T12:00:00Z' }));
+    const pmDeps = {
+      brainDb: {} as never,
+      config: {} as never,
+      embedder: {} as never,
+    };
+
+    const report = await reconcileMergeLifecycle(db as unknown as object, projectDir, {
+      pmDeps,
+    });
+
+    expect(mockUpdateTask).toHaveBeenCalledWith(
+      pmDeps.brainDb,
+      pmDeps.config,
+      pmDeps.embedder,
+      'VNM-1.1',
+      'done'
+    );
+    expect(report.errors).toEqual([]);
+  });
+
+  it('skips PM task advance when pmDeps absent', async () => {
+    const db = makeDbMock([makeDelivery()]);
+    mockGetPr.mockReturnValue(makePr({ state: 'merged' }));
+
+    await reconcileMergeLifecycle(db as unknown as object, projectDir);
+
+    expect(mockUpdateTask).not.toHaveBeenCalled();
+  });
+
+  it('falls back to ctx.now when GH does not report mergedAt', async () => {
+    const db = makeDbMock([makeDelivery()]);
+    mockGetPr.mockReturnValue(makePr({ state: 'merged' }));
+    const fixedNow = Date.UTC(2026, 3, 28, 13, 0, 0);
+
+    await reconcileMergeLifecycle(db as unknown as object, projectDir, {
+      now: () => fixedNow,
+    });
+
+    expect(mockUpdateDelivery).toHaveBeenCalledWith(db, 'agent-1', 'merged', {
+      pr_merged_at: new Date(fixedNow).toISOString(),
+    });
   });
 
   it('reclaims terminated worktrees on every pass', async () => {

--- a/src/modules/agents/auto-merge.ts
+++ b/src/modules/agents/auto-merge.ts
@@ -15,6 +15,10 @@ export interface PrStatus {
   mergeStateStatus?: string;
   state: 'open' | 'closed' | 'merged';
   failedChecks: string[];
+  /** ISO timestamp from GitHub when the PR merged. Only populated when state==='merged'. */
+  mergedAt?: string;
+  /** ISO timestamp from GitHub when the PR closed. Populated for both merged and closed states. */
+  closedAt?: string;
 }
 
 export type MergeStrategy = 'squash' | 'merge' | 'rebase';
@@ -40,7 +44,7 @@ export function getPrForBranch(branch: string, projectDir: string): PrStatus | n
         'view',
         branch,
         '--json',
-        'number,headRefName,state,mergeable,mergeStateStatus,statusCheckRollup',
+        'number,headRefName,state,mergeable,mergeStateStatus,statusCheckRollup,mergedAt,closedAt',
       ],
       { cwd: projectDir, encoding: 'utf-8', stdio: 'pipe' }
     );
@@ -51,6 +55,8 @@ export function getPrForBranch(branch: string, projectDir: string): PrStatus | n
       mergeable: string;
       mergeStateStatus?: string;
       statusCheckRollup: Array<{ conclusion: string; state: string; name?: string }> | null;
+      mergedAt?: string | null;
+      closedAt?: string | null;
     };
 
     const checks = data.statusCheckRollup ?? [];
@@ -69,6 +75,8 @@ export function getPrForBranch(branch: string, projectDir: string): PrStatus | n
       mergeStateStatus: data.mergeStateStatus,
       state: data.state.toLowerCase() as PrStatus['state'],
       failedChecks,
+      mergedAt: data.mergedAt ?? undefined,
+      closedAt: data.closedAt ?? undefined,
     };
   } catch {
     return null;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -71,7 +71,11 @@ async function initV2Runtime(
   (svc as unknown as Record<string, unknown>)._workflowRuntime = runtime;
   process.stderr.write('Workflow runtime active\n');
 
-  const mergeReconciler = new MergeLifecycleReconciler(svc.db, resolveProjectDir(svc));
+  const mergeReconciler = new MergeLifecycleReconciler(svc.db, resolveProjectDir(svc), 60_000, {
+    brainDb: svc.db,
+    config: svc.config,
+    embedder: svc.embedder,
+  });
   mergeReconciler.start();
   process.stderr.write('Merge-lifecycle reconciler active (60s timer)\n');
 

--- a/src/services/merge-lifecycle-reconciler.ts
+++ b/src/services/merge-lifecycle-reconciler.ts
@@ -5,9 +5,15 @@ import { getRawDb } from '../utils/db.js';
 import { getPrForBranch, rerunPrChecks } from '../modules/agents/auto-merge.js';
 import { rebaseInIsolationDetailed } from '../modules/agents/rebase-isolation.js';
 import { reclaimTerminatedAllocations } from '../modules/agents/worktree.js';
-import { enableAutoMerge, type DeliveryRecord } from '../modules/agents/delivery.js';
+import {
+  enableAutoMerge,
+  updateDeliveryStatus,
+  type DeliveryRecord,
+} from '../modules/agents/delivery.js';
 import { recoverBranchForAgent } from '../server/orchestration.js';
 import { loadFlakyTests } from '../modules/agents/delivery-monitor.js';
+import { updateTaskStatus } from '../modules/pm/data/task-ops.js';
+import type { BrainConfig, Embedder } from '../types.js';
 
 export interface ReconcileReport {
   prsScanned: number;
@@ -16,7 +22,22 @@ export interface ReconcileReport {
   autoMergeArmed: number[];
   worktreesReclaimed: string[];
   branchesRecovered: string[];
+  /** Tasks whose delivery+PM state advanced because GitHub reports the PR merged. */
+  deliveriesMerged: string[];
+  /** Tasks whose delivery state advanced because GitHub reports the PR closed without merge. */
+  deliveriesClosed: string[];
   errors: { kind: string; target: string; reason: string }[];
+}
+
+/**
+ * Optional dependencies needed to advance PM task status when a PR's terminal
+ * state is observed. Absent in tests / contexts that only need the
+ * delivery_states-level reconcile path.
+ */
+export interface PmDeps {
+  brainDb: BrainDB;
+  config: BrainConfig;
+  embedder: Embedder;
 }
 
 interface OrphanAgentRow {
@@ -55,6 +76,8 @@ function emptyReport(): ReconcileReport {
     autoMergeArmed: [],
     worktreesReclaimed: [],
     branchesRecovered: [],
+    deliveriesMerged: [],
+    deliveriesClosed: [],
     errors: [],
   };
 }
@@ -120,6 +143,8 @@ interface ReconcileOptions {
   ciRerunCooldown?: Map<string, number>;
   /** Override for testability — defaults to Date.now(). */
   now?: () => number;
+  /** Wire PM task status advance on PR-terminal observations. */
+  pmDeps?: PmDeps;
 }
 
 /**
@@ -146,7 +171,12 @@ export async function reconcileMergeLifecycle(
   const now = opts.now ?? Date.now;
   const flakyTests = loadFlakyTests(projectDir);
 
-  await reconcilePrActions(rawDb, projectDir, report, { cooldown, now, flakyTests });
+  await reconcilePrActions(rawDb, projectDir, report, {
+    cooldown,
+    now,
+    flakyTests,
+    pmDeps: opts.pmDeps,
+  });
   reconcileWorktrees(rawDb, projectDir, report);
   await reconcileOrphanBranches(rawDb, projectDir, report);
 
@@ -157,6 +187,7 @@ interface PrActionContext {
   cooldown: Map<string, number>;
   now: () => number;
   flakyTests: string[];
+  pmDeps?: PmDeps;
 }
 
 async function reconcilePrActions(
@@ -170,8 +201,70 @@ async function reconcilePrActions(
     if (!delivery.branch || !delivery.pr_number) continue;
     report.prsScanned += 1;
     const pr = getPrForBranch(delivery.branch, projectDir);
-    if (!pr || pr.state !== 'open') continue;
+    if (!pr) continue;
+    if (pr.state === 'merged' || pr.state === 'closed') {
+      await advanceTerminatedDelivery(rawDb, delivery, pr, report, ctx);
+      continue;
+    }
+    if (pr.state !== 'open') continue;
     await reconcileSinglePr(delivery.branch, delivery.pr_number, pr, projectDir, report, ctx);
+  }
+}
+
+/**
+ * GitHub reports the PR is no longer open: advance delivery_states past its
+ * blocking ACTIVE_PR_STATUSES so worktree reclaim (VNM-56.69) can fire, and
+ * — when PM dependencies are available — close the PM task. This is what
+ * makes standalone `brain_agent_dispatch` ergonomically equivalent to a
+ * workstream-dispatch wave: both paths converge on this observer.
+ */
+async function advanceTerminatedDelivery(
+  rawDb: Database.Database,
+  delivery: DeliveryRecord,
+  pr: NonNullable<ReturnType<typeof getPrForBranch>>,
+  report: ReconcileReport,
+  ctx: PrActionContext
+): Promise<void> {
+  const taskId = delivery.task_id;
+  if (!taskId) return;
+
+  try {
+    if (pr.state === 'merged') {
+      const mergedAt = pr.mergedAt ?? new Date(ctx.now()).toISOString();
+      updateDeliveryStatus(rawDb, delivery.agent_id, 'merged', { pr_merged_at: mergedAt });
+      report.deliveriesMerged.push(taskId);
+    } else {
+      // closed without merge — stall with explicit reason so reclaim can fire
+      updateDeliveryStatus(rawDb, delivery.agent_id, 'stalled', {
+        stall_reason: 'pr-closed',
+      });
+      report.deliveriesClosed.push(taskId);
+    }
+  } catch (err) {
+    report.errors.push({ kind: 'delivery-advance', target: taskId, reason: errMsg(err) });
+    return;
+  }
+
+  if (!ctx.pmDeps) return;
+
+  const nextStatus = pr.state === 'merged' ? 'done' : 'cancelled';
+  try {
+    const result = await updateTaskStatus(
+      ctx.pmDeps.brainDb,
+      ctx.pmDeps.config,
+      ctx.pmDeps.embedder,
+      taskId,
+      nextStatus
+    );
+    if (!result.ok) {
+      report.errors.push({
+        kind: 'pm-advance',
+        target: taskId,
+        reason: result.error.message,
+      });
+    }
+  } catch (err) {
+    report.errors.push({ kind: 'pm-advance', target: taskId, reason: errMsg(err) });
   }
 }
 
@@ -285,7 +378,8 @@ export class MergeLifecycleReconciler {
   constructor(
     private readonly db: BrainDB | Database.Database,
     private readonly projectDir: string,
-    private readonly intervalMs: number = 60_000
+    private readonly intervalMs: number = 60_000,
+    private readonly pmDeps?: PmDeps
   ) {}
 
   start(): void {
@@ -308,6 +402,7 @@ export class MergeLifecycleReconciler {
     try {
       const report = await reconcileMergeLifecycle(this.db, this.projectDir, {
         ciRerunCooldown: this.cooldown,
+        pmDeps: this.pmDeps,
       });
       this.lastReport = report;
       return report;


### PR DESCRIPTION
## Summary

Standalone `brain_agent_dispatch` had no observer to advance delivery rows past `pr-open` after a PR merged on GitHub. That left worktrees pinned (because `ACTIVE_DELIVERY_STATUSES` short-circuits worktree reclaim) and PM tasks stuck `in-progress`. Today's session needed manual `UPDATE delivery_states` + 14 manual `brain_pm_task_complete` calls to clear yesterday's autonomous run.

The merge-lifecycle reconciler already scans active deliveries on a 60s tick. This PR extends `reconcilePrActions` to:

- Advance `delivery_states.status` to `merged` (with `pr_merged_at` from GitHub's `mergedAt`) when GH reports the PR merged
- Advance to `stalled` (with `stall_reason='pr-closed'`) when the PR is closed without merge
- Advance the PM task to `done` / `cancelled` when `pmDeps` are wired (always wired in `brain serve`)

Once delivery exits `ACTIVE_DELIVERY_STATUSES`, the VNM-56.69 force-release branch in `reclaimTerminatedAllocations` finally fires — both fixes become active together.

## Why this is the load-bearing fix for autonomy

VNM-56.69 ships correct code that is dormant in production: the reclaim loop short-circuits on `pr-open` *before* reaching the new force-release path. Without VNM-56.71 advancing delivery state, every standalone dispatch leaves a stale worktree until somebody hand-advances the row. With this PR, both fixes converge — workstream-dispatch and standalone-dispatch reach the same terminal-state behavior.

## Test plan

- [x] 4 new unit tests in `__tests__/services/merge-lifecycle-reconciler.test.ts` covering merged/closed PR observation, pmDeps wiring, and ctx.now fallback
- [x] Existing 14 reconciler tests still pass (updated 1 stale test that relied on the old skip-non-open behavior)
- [x] Full reconciler suite: 18/18 pass
- [x] Adjacent suites (auto-merge, dispatch-loop, orchestration, serve, workflow): 313/313 pass
- [x] Typecheck + ESLint clean on changed files
- [ ] Live e2e: dispatch a fresh task, observe its PR merge, verify reclaim fires within next reconciler tick (60s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)