### PR TITLE
Subtract file-ownership only from in-flight peers (VNM-48.280-282)

### DIFF
--- a/__tests__/modules/agents/file-ownership-ext.test.ts
+++ b/__tests__/modules/agents/file-ownership-ext.test.ts
@@ -6,6 +6,13 @@ import { createWorkstream } from '../../../src/modules/pm/data/workstream-ops.js
 import type { BrainConfig } from '../../../src/types.js';
 import { extractPathReferences } from '../../../src/modules/agents/extensions/file-ownership-ext.js';
 import { fileOwnershipExtension } from '../../../src/modules/agents/extensions/file-ownership-ext.js';
+import { createAgent, updateAgentStatus } from '../../../src/modules/agents/data.js';
+import {
+  agentsMigrationV1,
+  agentsMigrationV2,
+  agentsMigrationV3,
+  agentsMigrationV4,
+} from '../../../src/modules/agents/schema.js';
 
 const embedder = createMockEmbedder();
 
@@ -65,6 +72,13 @@ describe('fileOwnershipExtension.compute', () => {
       embedder: 'local',
     };
 
+    // Ensure agents tables exist (template DB doesn't include them)
+    const rawDb = (db as unknown as { db: unknown }).db;
+    agentsMigrationV1.up(rawDb);
+    agentsMigrationV2.up(rawDb);
+    agentsMigrationV3.up(rawDb);
+    agentsMigrationV4.up(rawDb);
+
     await createProject(db, config, embedder, { name: 'Test', prefix: 'OWN' });
     await createWorkstream(db, config, embedder, { project: 'OWN', name: 'Alpha' });
   });
@@ -114,8 +128,9 @@ describe('fileOwnershipExtension.compute', () => {
     expect(result!.rules[0].patterns).toContain('src/modules/pm/commands/dispatch.ts');
   });
 
-  it('assigns separate ownership to wave peers', async () => {
-    // Two tasks in the same wave (no deps on each other)
+  it('does NOT include peer scope when peer has no in-flight agent (solo dispatch)', async () => {
+    // Two tasks in the same workstream — but no agents are dispatched.
+    // Solo dispatch of OWN-01.01 should give it full scope from its own description.
     await createTestTask(db, config, embedder, {
       project: 'OWN',
       workstream: 1,
@@ -134,17 +149,82 @@ describe('fileOwnershipExtension.compute', () => {
       taskDisplayId: 'OWN-01.01',
     });
     expect(result).toBeDefined();
+    expect(result!.rules).toHaveLength(1);
+
+    const agentA = result!.rules.find((r) => r.agentId === 'OWN-01.01');
+    expect(agentA).toBeDefined();
+    expect(agentA!.patterns).toContain('src/services/search.ts');
+    // Peer not included because OWN-01.02 has no in-flight agent
+    const agentB = result!.rules.find((r) => r.agentId === 'OWN-01.02');
+    expect(agentB).toBeUndefined();
+  });
+
+  it('subtracts peer scope when peer has an in-flight agent', async () => {
+    await createTestTask(db, config, embedder, {
+      project: 'OWN',
+      workstream: 1,
+      name: 'Worker A',
+      description: 'Modify src/services/search.ts for improved results',
+    });
+    await createTestTask(db, config, embedder, {
+      project: 'OWN',
+      workstream: 1,
+      name: 'Worker B',
+      description: 'Modify src/services/graph.ts for better traversal',
+    });
+
+    // Mark OWN-01.02 as in-flight
+    const peerAgentId = createAgent(db, {
+      name: 'peer',
+      parent: 'test',
+      brain_task: 'OWN-01.02',
+    });
+    updateAgentStatus(db, peerAgentId, 'active', { pid: 9999 });
+
+    const result = fileOwnershipExtension.compute({
+      db,
+      taskDisplayId: 'OWN-01.01',
+    });
+    expect(result).toBeDefined();
     expect(result!.rules).toHaveLength(2);
 
     const agentA = result!.rules.find((r) => r.agentId === 'OWN-01.01');
     const agentB = result!.rules.find((r) => r.agentId === 'OWN-01.02');
-    expect(agentA).toBeDefined();
-    expect(agentB).toBeDefined();
     expect(agentA!.patterns).toContain('src/services/search.ts');
     expect(agentB!.patterns).toContain('src/services/graph.ts');
   });
 
-  it('resolves conflicts by prioritizing current task', async () => {
+  it('ignores peers whose agents are in terminal status', async () => {
+    await createTestTask(db, config, embedder, {
+      project: 'OWN',
+      workstream: 1,
+      name: 'Worker A',
+      description: 'Modify src/services/search.ts',
+    });
+    await createTestTask(db, config, embedder, {
+      project: 'OWN',
+      workstream: 1,
+      name: 'Worker B',
+      description: 'Modify src/services/graph.ts',
+    });
+
+    // Peer agent already finished — should NOT subtract scope
+    const peerAgentId = createAgent(db, {
+      name: 'peer',
+      parent: 'test',
+      brain_task: 'OWN-01.02',
+    });
+    updateAgentStatus(db, peerAgentId, 'completed', { exit_reason: 'done' });
+
+    const result = fileOwnershipExtension.compute({
+      db,
+      taskDisplayId: 'OWN-01.01',
+    });
+    expect(result!.rules).toHaveLength(1);
+    expect(result!.rules[0].agentId).toBe('OWN-01.01');
+  });
+
+  it('resolves conflicts by prioritizing current task when peer is in-flight', async () => {
     await createTestTask(db, config, embedder, {
       project: 'OWN',
       workstream: 1,
@@ -158,6 +238,13 @@ describe('fileOwnershipExtension.compute', () => {
       description: 'Modify src/shared.ts for feature B',
     });
 
+    const peerAgentId = createAgent(db, {
+      name: 'peer',
+      parent: 'test',
+      brain_task: 'OWN-01.02',
+    });
+    updateAgentStatus(db, peerAgentId, 'active', { pid: 9999 });
+
     const result = fileOwnershipExtension.compute({
       db,
       taskDisplayId: 'OWN-01.01',
@@ -169,7 +256,6 @@ describe('fileOwnershipExtension.compute', () => {
     const agentB = result!.rules.find((r) => r.agentId === 'OWN-01.02');
     expect(agentA).toBeDefined();
     expect(agentA!.patterns).toContain('src/shared.ts');
-    // agentB either has no rules or doesn't have the conflicting pattern
     if (agentB) {
       expect(agentB.patterns).not.toContain('src/shared.ts');
     }

--- a/src/modules/agents/data.ts
+++ b/src/modules/agents/data.ts
@@ -192,6 +192,25 @@ export function countActiveAgents(db: unknown): number {
   return row.n;
 }
 
+/**
+ * Return brain_task display IDs of agents that are not in a terminal status
+ * (i.e. pending or active), excluding the given task. Used by file-ownership
+ * computation to subtract scope only from peers that are actually in flight,
+ * rather than from every theoretically-parallel task in the wave.
+ */
+export function findInFlightAgentTasks(db: unknown, excludeTaskId: string): string[] {
+  const raw = toRaw(db);
+  const rows = raw
+    .prepare(
+      `SELECT DISTINCT brain_task FROM agents
+        WHERE brain_task IS NOT NULL
+          AND brain_task != ?
+          AND status IN ('pending', 'active')`
+    )
+    .all(excludeTaskId) as { brain_task: string }[];
+  return rows.map((r) => r.brain_task);
+}
+
 /** Retrieve full context object or a specific key for an agent. */
 export function getAgentContext(
   db: unknown,

--- a/src/modules/agents/extensions/file-ownership-ext.ts
+++ b/src/modules/agents/extensions/file-ownership-ext.ts
@@ -1,11 +1,11 @@
 import type { DispatchExtension, DispatchExtensionInput } from '../dispatch-extensions.js';
 import type { FileOwnershipManifest } from '../file-ownership.js';
 import { buildOwnershipManifest, checkConflicts, formatOwnershipBrief } from '../file-ownership.js';
-import { computeWaves } from '../../pm/engine/dependency.js';
 import { readTaskBody } from '../../pm/engine/dispatch.js';
 import { getPmNotes } from '../../pm/data/queries.js';
 import type { TaskMetadata } from '../../pm/types.js';
 import type { BrainDB } from '../../../services/brain-db.js';
+import { findInFlightAgentTasks } from '../data.js';
 
 // TODO: Future improvement — write computed ownership to the persisted manifest
 // (`.claude/ownership.json`) before agent dispatch so the hook check
@@ -37,13 +37,6 @@ function pathsToPatterns(paths: string[]): string[] {
   });
 }
 
-function resolveProject(db: BrainDB, taskDisplayId: string): string | null {
-  const notes = getPmNotes(db, 'task', { display_id: taskDisplayId });
-  if (notes.length === 0) return null;
-  const meta = JSON.parse(notes[0].metadata!) as TaskMetadata;
-  return meta.project;
-}
-
 function getTaskDescription(db: BrainDB, taskDisplayId: string): string {
   const notes = getPmNotes(db, 'task', { display_id: taskDisplayId });
   if (notes.length === 0) return '';
@@ -52,18 +45,18 @@ function getTaskDescription(db: BrainDB, taskDisplayId: string): string {
   return [meta.title ?? '', body].join('\n');
 }
 
-function findWavePeers(db: BrainDB, project: string, taskDisplayId: string): string[] {
-  const waves = computeWaves(db, project);
-  for (const wave of waves) {
-    if (wave.taskIds.includes(taskDisplayId)) {
-      return wave.taskIds.filter((id) => id !== taskDisplayId);
-    }
-  }
-  return [];
-}
-
 /**
  * Dynamically compute file ownership from task descriptions for dispatch context.
+ *
+ * Subtracts scope only from peers whose agent is currently in flight
+ * (status pending/active). Solo dispatches with no concurrent agents
+ * therefore receive their full natural scope; wave dispatches subtract
+ * from siblings as they spawn.
+ *
+ * Previously this used the entire computed-waves peer list — including
+ * every task that *could* run in parallel based on dep analysis — which
+ * for large projects produced empty authorized-to-modify lists for
+ * solo dispatches. (Tracked as VNM-48.280/.281/.282.)
  *
  * This produces **recommendations** included in the agent's dispatch prompt so it
  * knows which files it should touch. It is NOT the enforcement mechanism — the
@@ -74,10 +67,7 @@ function findWavePeers(db: BrainDB, project: string, taskDisplayId: string): str
 function computeOwnership(input: DispatchExtensionInput): FileOwnershipManifest | undefined {
   try {
     const { db, taskDisplayId } = input;
-    const project = resolveProject(db, taskDisplayId);
-    if (!project) return undefined;
-
-    const peers = findWavePeers(db, project, taskDisplayId);
+    const peers = findInFlightAgentTasks(db, taskDisplayId);
     const allAgents = [taskDisplayId, ...peers];
 
     const assignments: Array<{ agentId: string; patterns: string[] }> = [];


### PR DESCRIPTION
## Failure mode

Solo dispatches (\`brain_agent_dispatch taskId=X\`) consistently arrived with an empty \`authorized to modify\` list. Two observed cases:

- **2026-04-30**: VNM-48.27 dispatched, agent had no scope, correctly identified the task as obsolete and didn't ship garbage (per VNM-56.65 protocol).
- **2026-05-02**: VNM-56.72 dispatched, agent had no scope and could not have committed the fix even if it had completed.

Root cause in \`computeOwnership\` (file-ownership-ext.ts):

\`\`\`ts
const peers = findWavePeers(db, project, taskDisplayId);
const allAgents = [taskDisplayId, ...peers];
\`\`\`

\`findWavePeers\` returns *every* task in the same dependency wave — for VNM that's 200+ tasks. They all claim overlapping scopes (\`src/modules/\`, \`src/server/\`, \`src/services/\`, \`docs/\`, \`__tests__/\`), so when conflicts are resolved any non-priority task ends up with empty patterns.

## Fix

Subtract scope only from peers whose **agent is actually in flight** (status \`pending\` or \`active\`):

- Add \`findInFlightAgentTasks(db, excludeTaskId)\` in \`src/modules/agents/data.ts\`
- Replace \`findWavePeers\` with the in-flight query in \`file-ownership-ext.ts\`
- Drop unused \`computeWaves\` import + \`resolveProject\` helper

Solo dispatches now receive their full natural scope. Wave dispatches still subtract from siblings as they spawn (each new agent adds itself to the active set; subsequent dispatches see it). For truly simultaneous wave-spawning, the coordinator dispatches sequentially with each \`createAgent\` call landing before the next \`computeOwnership\` runs — so wave behavior is preserved.

## Tests

\`__tests__/modules/agents/file-ownership-ext.test.ts\`: 4 new tests, 1 retained:
- ✅ Solo dispatch returns single rule (peer in same workstream but not dispatched)
- ✅ Subtracts peer scope when peer has in-flight (\`active\`) agent
- ✅ Ignores peers whose agents are in terminal status (\`completed\`)
- ✅ Resolves conflicts by prioritizing current task when peer is in-flight
- Existing path-extraction tests preserved

Full unit suite: 1467/1467 pass. Typecheck + lint clean.

## Backward compatibility

The hook in \`src/hooks/checks/ownership.ts\` (which enforces ownership at write time) is unchanged. It reads from the persisted \`.claude/ownership.json\` manifest, not the dispatch-time computation. The dispatch-time manifest is still surfaced in agent prompts as advisory; it's now just *correct*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)